### PR TITLE
Don't fail on add_video if the video is forbidden

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@ v0.4 - 2014/05/09
 * Supports also ActiveSupport 3 and Ruby 1.9.3 (not just AS4 + Ruby 2)
 * Fix parsing annotation and timestamps longer than 1 hour
 * Fix delegating tags from resources to snippets
-* Two options to add videos to a playlist: fail or not if a video is missing
+* Two options to add videos to a playlist: fail or not if a video is missing or its account terminated
 * Allow to configure Yt credentials through environment variables
 
 v0.3.0 - 2014/04/16

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.4.8'
+    gem 'yt', '~> 0.4.9'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/associations/playlist_items.rb
+++ b/lib/yt/associations/playlist_items.rb
@@ -11,7 +11,7 @@ module Yt
       end
 
       def add_video(video_id)
-        playlist_items.insert({id: video_id, kind: :video}, ignore_not_found: true)
+        playlist_items.insert({id: video_id, kind: :video}, ignore_errors: true)
       end
 
       def add_video!(video_id)

--- a/lib/yt/collections/playlist_items.rb
+++ b/lib/yt/collections/playlist_items.rb
@@ -12,7 +12,7 @@ module Yt
         snippet = {playlistId: @parent.id, resourceId: resource}
         do_insert body: {snippet: snippet}, params: {part: 'snippet,status'}
       rescue Yt::RequestError => error
-        raise error unless options[:ignore_not_found] && error.reasons.include?('videoNotFound')
+        raise error unless options[:ignore_errors] && (error.reasons.include?('videoNotFound') || error.reasons.include?('forbidden'))
       end
 
       def delete_all(params = {})

--- a/spec/associations/device_auth/playlist_items_spec.rb
+++ b/spec/associations/device_auth/playlist_items_spec.rb
@@ -30,6 +30,12 @@ describe Yt::Associations::PlaylistItems, scenario: :device_app do
       it { expect(@playlist.add_video video_id).to be_nil }
       it { expect{@playlist.add_video video_id}.not_to change{@playlist.playlist_items.count} }
     end
+
+    context 'given a video of a terminated account' do
+      let(:video_id) { 'kDCpdKeTe5g' }
+      it { expect(@playlist.add_video video_id).to be_nil }
+      it { expect{@playlist.add_video video_id}.not_to change{@playlist.playlist_items.count} }
+    end
   end
 
   describe '#add_video!' do
@@ -40,6 +46,11 @@ describe Yt::Associations::PlaylistItems, scenario: :device_app do
 
     context 'given an unknown video' do
       let(:video_id) { 'not-a-video' }
+      it { expect{@playlist.add_video! video_id}.to raise_error Yt::RequestError }
+    end
+
+    context 'given a video of a terminated account' do
+      let(:video_id) { 'kDCpdKeTe5g' }
       it { expect{@playlist.add_video! video_id}.to raise_error Yt::RequestError }
     end
   end


### PR DESCRIPTION
An example is https://www.youtube.com/watch?v=kDCpdKeTe5g

"This video is no longer available because the YouTube account associated with this video has been terminated."
