### PR TITLE
Playlist#update ONLY changes the specified attrs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.4.9)
+    yt (0.4.10)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@ v0.4 - 2014/05/09
 * Fix delegating tags from resources to snippets
 * Two options to add videos to a playlist: fail or not if a video is missing or its account terminated
 * Allow to configure Yt credentials through environment variables
+* When updating a playlist, only changes the specified attributes
 
 v0.3.0 - 2014/04/16
 --------------------

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.4.9'
+    gem 'yt', '~> 0.4.10'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/models/playlist.rb
+++ b/lib/yt/models/playlist.rb
@@ -9,21 +9,17 @@ module Yt
       !exists?
     end
 
-    # Valid body (no defaults) are: title (string), description (string), privacy_status (string),
-    # tags (array of strings) - since title is required, we set it again if it's not passed
     def update(options = {})
-      parts, body = [], {id: @id}
-
       options[:title] ||= title
-      parts << :snippet
-      body[:snippet] = options.slice :title, :description, :tags
+      options[:description] ||= description
+      options[:tags] ||= tags
+      options[:privacy_status] ||= privacy_status
 
-      if status = options[:privacy_status]
-        parts << :status
-        body[:status] = {privacyStatus: status}
-      end
+      snippet = options.slice :title, :description, :tags
+      status = {privacyStatus: privacy_status}
+      body = {id: @id, snippet: snippet, status: status}
+      params = {params: {part: 'snippet,status'}, body: body}
 
-      params = {params: {part: parts.join(',')}, body: body}
       do_update(params, expect: Net::HTTPOK) do |data|
         @id = data['id']
         @snippet = Snippet.new data: data['snippet'] if data['snippet']

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.4.9'
+  VERSION = '0.4.10'
 end

--- a/spec/models/playlist_spec.rb
+++ b/spec/models/playlist_spec.rb
@@ -31,8 +31,7 @@ describe Yt::Playlist do
   end
 
   describe '#update' do
-    # TODO: separate stubs to show options translate into do_insert params
-    let(:attrs) { {id: 'PLSWYkYzOr', snippet: {'title'=>'old'}} }
+    let(:attrs) { {id: 'PLSWYkYzOr', snippet: {'title'=>'old'}, status: {"privacyStatus"=>"public"}} }
     before { playlist.stub(:do_update).and_yield 'snippet'=>{'title'=>'new'} }
 
     it { expect(playlist.update title: 'new').to be_true }


### PR DESCRIPTION
By default, the YouTube API method to update a playlist would also
change to "nil" all the attributes that are not explicitly given.

This behavior is counter-intuitive and dangerous
