### PR TITLE
pass through specified privacy_status to the request

### DIFF
--- a/lib/yt/models/playlist.rb
+++ b/lib/yt/models/playlist.rb
@@ -16,7 +16,7 @@ module Yt
       options[:privacy_status] ||= privacy_status
 
       snippet = options.slice :title, :description, :tags
-      status = {privacyStatus: privacy_status}
+      status = {privacyStatus: options[:privacy_status]}
       body = {id: @id, snippet: snippet, status: status}
       params = {params: {part: 'snippet,status'}, body: body}
 


### PR DESCRIPTION
https://github.com/Fullscreen/yt/pull/5 introduced a bug which essentially ignores the privacy_status passed in through the options hash
