### PR TITLE
Allow for query parameter on has_many :videos

### DIFF
--- a/lib/yt/collections/base.rb
+++ b/lib/yt/collections/base.rb
@@ -15,8 +15,8 @@ module Yt
         @auth = options[:auth]
       end
 
-      def self.of(parent)
-        new parent: parent, auth: parent.auth
+      def self.of(parent, options = {})
+        new options.merge parent: parent, auth: parent.auth
       end
     end
   end

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -5,6 +5,11 @@ module Yt
   module Collections
     class Videos < Base
 
+      def initialize(options)
+        @q = options[:q]
+        super
+      end
+
     private
 
       def new_item(data)
@@ -13,7 +18,14 @@ module Yt
 
       def list_params
         super.tap do |params|
-          params[:params] = {channelId: @parent.id, type: :video, maxResults: 50, part: 'snippet'}
+          params[:params] = {type: :video, maxResults: 50, part: 'snippet'}
+
+          if @parent.auth == @auth
+            params[:params].merge! forMine: true, q: @q
+          else
+            params[:params].merge! channelId: @parent.id
+          end
+
           params[:path] = '/youtube/v3/search'
         end
       end

--- a/lib/yt/models/base.rb
+++ b/lib/yt/models/base.rb
@@ -18,9 +18,9 @@ module Yt
         mod = attributes.sub(/.*\./, '').camelize
         collection = "Yt::Collections::#{mod.pluralize}".constantize
 
-        define_method attributes do
+        define_method attributes do |options = {}|
           ivar = instance_variable_get "@#{attributes}"
-          instance_variable_set "@#{attributes}", ivar || collection.of(self)
+          instance_variable_set "@#{attributes}", ivar || collection.of(self, options)
         end
       end
 


### PR DESCRIPTION
@claudiofullscreen Would love to get your thoughts.

I'm trying to replace youtube_it with YT, but currently the only missing piece is querying for videos.

This allows for the following usage (tested on my account):

``` ruby
YT::Account.new(credentials).videos.map &:title
 => ["asdf",  "Vegas Indoor Skydiving", "Swing", "UCSD Dance by the Shores Adv. Hustle"]

YT::Account.new(credentials).videos(q: 'vegas').map &:title
=> ["Vegas Indoor Skydiving"]
```

Wanted to get your thoughts before i spend time fixing specs.
