### PR TITLE
Sort Channel#videos by most recent first

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.7.2)
+    yt (0.7.3)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ v0.7 - 2014/06/18
 * More snippet methods for PlaylistItem (channel_id, channel_title, playlist_id, video_id)
 * More status methods for PlaylistItem (privacy_status, public?, private?, unlisted?)
 * Add video.update to update title, description, tags and categoryId of a video
+* Sort channel.videos by most recent first
 
 v0.6 - 2014/06/05
 -----------------

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.7.2'
+    gem 'yt', '~> 0.7.3'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -28,8 +28,9 @@ module Yt
       end
 
       def videos_params
+        params = {type: :video, maxResults: 50, part: 'snippet', order: 'date'}
         @extra_params ||= {}
-        {type: :video, maxResults: 50, part: 'snippet'}.merge @extra_params
+        params.merge @extra_params
       end
     end
   end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.7.2'
+  VERSION = '0.7.3'
 end


### PR DESCRIPTION
The default for YouTube is instead to sort by relevance
https://developers.google.com/youtube/v3/docs/search/list

> The order parameter specifies the method that will be used to order resources in the API response. The default value is relevance.
> Acceptable values are:
> date – Resources are sorted in reverse chronological order based on the date they were created.
> rating – Resources are sorted from highest to lowest rating.
> relevance – Resources are sorted based on their relevance to the search query. This is the default value for this parameter.
> title – Resources are sorted alphabetically by title.
> videoCount – Channels are sorted in descending order of their number of uploaded videos.
> viewCount – Resources are sorted from highest to lowest number of views.
