### PR TITLE
Metrics for non content owners

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ matrix:
   - rvm: 1.9.3
     gemfile: gemfiles/Gemfile.activesupport-3.x
     env:
-    - secure: Z93M7+GBYG8A7Dsjwcsgj/8AmdJ5X2KezBk9qelw89/OtAqIp1zMNQehTEg24p/NygkNjnGycb3DQuW++31v4c+mt5/MgDDhd2jXJ4+js+3gAMAIpiMtPJfEOvmKxLbC0uMaQhXLn7dGMnn8ed7hh6Zu/8P+17qZvVeI0thI3Dg=
+    - secure: OsmWyhhYNILEb1lhqxPX+iEfbWzC3dELuxQ7JGP9iN/FhqBtlV51cu+u2cBBdql6Gzuqi4VlMEeJSX0PQUmzOsMb0vHhOJDyp4a32NE+xry8LOT8XdCwni20ZBcUeFxC5hMUVebPuhqBTFjBWbXQKwKSXIdPnNWz31d9kyGIsxk=
   - rvm: 2.0.0
     gemfile: gemfiles/Gemfile.activesupport-4.x
     env:
-    - secure: eIxGZcTZFVMxn0cxjaknhflAR78L6q+Q2G6jCXnFxqj8ARfgAS1F8v7ErkGaJ9h6dxfsH+5evhj4ZUc/gvHaqs8jcT9CVGUZsC7jpZz3gkfQ9k7Tm3sTnSfv4HbqGM8OkCJkLNOUQypmGr+mkPQskroNPhm6WT9Ml1vGq1RSTow=
+    - secure: FrmFA2BE0FYyuKsf0FEO0EAXY+h048HbD1p3lu5XPo9/lxpAl7wM5m12HsnJQuNY6UlUmZ5bp9f8upCBZpz7cLZK5e/FWLWSvkv3Fts+NVsbAcVtFgvBKOCgTznZi/qgUtqbWBevkM3gyXyylzdB+c4wWjoOO/xSDVR227m8nMA=
 env:
   global:
   - secure: ApPj5c9h6xk+AbHHf4KXL10QnleYCWwcp2+qMFolrS6RWR5vhrnKq1UBo0h59HuvXeOQIgZ/GmocuSEZovS9c1hQP3n0PHSNEnGUNJyn6CS3BiPQSWmC3p2pONo1Xv+hVWfzDoEv80b82GX5P5x/l1BSqhpxLA9geITJprWsoLg=

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.7.4)
+    yt (0.7.5)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@ v0.7 - 2014/06/18
 * Sort channel.videos by most recent first
 * Extract Reports (earnings, views) into module with macro `has_report`
 * New channel reports: comments, likes, dislikes, shares and impressions
+* Allow both normal and partnered channels to retrieve reports about views, comments, likes, dislikes, shares
 
 v0.6 - 2014/06/05
 -----------------

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ with an extra `code` parameter that looks something like `4/Ja60jJ7_Kw0`.
 Just pass the code to the following method to authenticate and initialize the account:
 
 ```ruby
-account = Yt::Account.new authorization_code: '4/Ja60jJ7_Kw0'
+account = Yt::Account.new authorization_code: '4/Ja60jJ7_Kw0', redirect_uri: redirect_uri
 account.email #=> (retrieves the account’s e-mail address)
 account.videos #=> (lists a video to an account’s playlist)
 ```

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ channel.subscribe #=> true
 
 channel.create_playlist title: 'New playlist' #=> true
 channel.delete_playlists title: 'New playlist' #=> [true]
+
+channel.views since: 7.days.ago #=> {Wed, 28 May 2014 => 12.0, Thu, 29 May 2014 => 3.0, …}
+channel.comments until: 2.days.ago #=> {Wed, 28 May 2014 => 9.0, Thu, 29 May 2014 => 4.0, …}
+channel.likes from: 8.days.ago #=> {Tue, 27 May 2014 => 7.0, Wed, 28 May 2014 => 0.0, …}
+channel.dislikes to: 2.days.ago #=> {Tue, 27 May 2014 => 0.0, Wed, 28 May 2014 => 1.0, …}
+channel.shares since: 7.days.ago, until: 7.days.ago  #=> {Wed, 28 May 2014 => 3.0}
 ```
 
 *The methods above require to be authenticated as a YouTube account (see below).*
@@ -433,7 +439,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.7.4'
+    gem 'yt', '~> 0.7.5'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/collections/authentications.rb
+++ b/lib/yt/collections/authentications.rb
@@ -9,7 +9,7 @@ module Yt
     private
 
       def new_item(data)
-        data['refresh_token'] = auth_params[:refresh_token]
+        data['refresh_token'] ||= auth_params[:refresh_token]
         Yt::Authentication.new data
       end
 

--- a/lib/yt/collections/reports.rb
+++ b/lib/yt/collections/reports.rb
@@ -20,14 +20,16 @@ module Yt
       def list_params
         super.tap do |params|
           params[:path] = '/youtube/analytics/v1/reports'
-          params[:params] = {}.tap do |params|
-            params['ids'] = "contentOwner==#{@auth.owner_name}"
-            params['filters'] = "channel==#{@parent.id}"
-            params['start-date'] = @days_range.begin
-            params['end-date'] = @days_range.end
-            params['metrics'] = @metric
-            params['dimensions'] = :day
-          end
+          params[:params] = @parent.reports_params.merge reports_params
+        end
+      end
+
+      def reports_params
+        {}.tap do |params|
+          params['start-date'] = @days_range.begin
+          params['end-date'] = @days_range.end
+          params['metrics'] = @metric
+          params['dimensions'] = :day
         end
       end
 

--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -24,6 +24,10 @@ module Yt
       #   @return [Yt::Collections::Videos] the videos owned by the account.
       has_many :videos
 
+      # @return [String] name of the CMS account, if the account is partnered.
+      # @return [nil] if the account is not a partnered content owner.
+      attr_reader :owner_name
+
       # @private
       # Tells `has_many :videos` that account.videos should return all the
       # videos *owned by* the account (public, private, unlisted).

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -121,6 +121,21 @@ module Yt
       def videos_params
         {channelId: id}
       end
+
+      # @private
+      # Tells `has_reports` to retrieve the reports from YouTube Analytics API
+      # either as a Channel or as a Content Owner.
+      # @see https://developers.google.com/youtube/analytics/v1/reports
+      def reports_params
+        {}.tap do |params|
+          if auth.owner_name
+            params['ids'] = "contentOwner==#{auth.owner_name}"
+            params['filters'] = "channel==#{id}"
+          else
+            params['ids'] = "channel==#{id}"
+          end
+        end
+      end
     end
   end
 end

--- a/lib/yt/models/content_owner.rb
+++ b/lib/yt/models/content_owner.rb
@@ -11,9 +11,6 @@ module Yt
       #   @return [Yt::Collection::PartneredChannels] the channels managed by the CMS account.
       has_many :partnered_channels
 
-      # @return [String] the name of the CMS account.
-      attr_reader :owner_name
-
       def initialize(options = {})
         super options
         @owner_name = options[:owner_name]

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.7.4'
+  VERSION = '0.7.5'
 end

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -70,6 +70,26 @@ describe Yt::Channel, :device_app do
     # rather than a more logical 4xx error. Hopefully this will get fixed
     # and this code (and test) removed.
     it { expect{channel.subscribe}.to raise_error Yt::Errors::ServerError }
+
+    it 'returns valid reports for channel-related metrics' do
+      # Some reports are only available to Content Owners.
+      # See content ownere test for more details about what the methods return.
+      expect{channel.views}.not_to raise_error
+      expect{channel.comments}.not_to raise_error
+      expect{channel.likes}.not_to raise_error
+      expect{channel.dislikes}.not_to raise_error
+      expect{channel.shares}.not_to raise_error
+      expect{channel.earnings}.to raise_error Yt::Errors::Unauthorized
+      expect{channel.impressions}.to raise_error Yt::Errors::Unauthorized
+
+      expect{channel.views_on 3.days.ago}.not_to raise_error
+      expect{channel.comments_on 3.days.ago}.not_to raise_error
+      expect{channel.likes_on 3.days.ago}.not_to raise_error
+      expect{channel.dislikes_on 3.days.ago}.not_to raise_error
+      expect{channel.shares_on 3.days.ago}.not_to raise_error
+      expect{channel.earnings_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
+      expect{channel.impressions_on 3.days.ago}.to raise_error Yt::Errors::Unauthorized
+    end
   end
 
   context 'given an unknown channel' do

--- a/spec/requests/as_content_owner/channel_spec.rb
+++ b/spec/requests/as_content_owner/channel_spec.rb
@@ -182,6 +182,18 @@ describe Yt::Channel, :partner do
         end
       end
 
+      describe 'shares can be retrieved for a specific day' do
+        context 'in which the channel was partnered' do
+          let(:shares) { channel.shares_on 5.days.ago}
+          it { expect(shares).to be_a Float }
+        end
+
+        context 'in which the channel was not partnered' do
+          let(:shares) { channel.shares_on 20.years.ago}
+          it { expect(shares).to be_nil }
+        end
+      end
+
       describe 'shares can be retrieved for a range of days' do
         let(:date) { 4.days.ago }
 


### PR DESCRIPTION
Let non-partnered channels retrieve five reports

Five reports (views, comments, likes, dislikes, shares) can now be retrieved
by channels without having to be authenticated as a content owner.

Notice that the channel’s account must have authorized the
yt-analytics.readonly scope to obtain the reports.
