### PR TITLE
Add OAuth for Devices    

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,3 +1,3 @@
 --no-private
-lib/yt/modules/reports.rb
+lib/yt/associations/has_reports.rb
 lib/**/*.rb

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.7.6)
+    yt (0.7.7)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -471,7 +471,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.7.6'
+    gem 'yt', '~> 0.7.7'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/bin/yt
+++ b/bin/yt
@@ -9,33 +9,96 @@ end
 
 ############################
 
-channel = Yt::Channel.new id: ARGV[0] || 'UCxO1tY8h1AhOz0T4ENwmpow'
+# account = Yt::Account.new refresh_token: ENV['YT_TEST_DEVICE_REFRESH_TOKEN']
 
-puts "Title: #{channel.title}"
-puts "Description: #{channel.description}"
-puts "Thumbnail: #{channel.thumbnail_url}"
-puts "Public? #{channel.public?}"
-puts "Views: #{channel.view_count}"
-puts "Comments: #{channel.comment_count}"
-puts "Videos: #{channel.video_count}"
-puts "Subscribers: #{channel.subscriber_count}"
-puts "Subscribers are visible? #{channel.subscriber_count_visible?}"
+# youtube.readonly and yt-analytics.readonly are not available with device :(
+account = Yt::Account.new scopes: %w(userinfo.email userinfo.profile youtube)
+0.upto(60) do |i|
+  begin
+    break if account.authentication
+  rescue Yt::Errors::MissingAuth => e
+    puts e.more_details if i.zero?
+    5.times {print '.'; sleep 1}
+  end
+end
 
-puts "Videos: "
-channel.videos.each do |video|
-  puts "  Annotations: #{video.annotations.count}"
-  puts "  Duration: #{video.duration}s"
+puts "\nACCOUNT:\n"
+puts "  ID: #{account.id}"
+puts "  Email: #{account.email}"
+puts "  Email verified? #{account.has_verified_email?}"
+puts "  Gender: #{account.gender}"
+puts "  Name: #{account.name}"
+puts "  Given Name: #{account.given_name}"
+puts "  Family Name: #{account.family_name}"
+puts "  Profile URL: #{account.profile_url}"
+puts "  Avatar URL: #{account.avatar_url}"
+puts "  Locale: #{account.locale}"
+puts "  Hd? #{account.hd}"
+
+puts "\nCHANNEL:\n"
+channel = account.channel
+puts "  Title: #{channel.title}"
+puts "  Description: #{channel.description.truncate(30)}"
+puts "  Thumbnail URL: #{channel.thumbnail_url}"
+puts "  Published at: #{channel.published_at}"
+puts "  Public? #{channel.public?}"
+puts "  Views: #{channel.view_count}"
+puts "  Comments: #{channel.comment_count}"
+puts "  Videos: #{channel.video_count}"
+puts "  Subscribers: #{channel.subscriber_count}"
+puts "  Subscribers are visible? #{channel.subscriber_count_visible?}"
+# These are not available with a device auth :(
+# puts "  Views: #{channel.views}"
+# puts "  Comments: #{channel.comments}"
+# puts "  Likes: #{channel.likes}"
+# puts "  Dislikes: #{channel.dislikes}"
+# puts "  Shares: #{channel.shares}"
+
+account.videos.first(5).each.with_index do |video, i|
+  puts "\nVIDEO #{i+1}:\n"
   puts "  Title: #{video.title}"
-  puts "  Description: #{video.description}"
-  puts "  Thumbnail: #{video.thumbnail_url}"
+  puts "  Description: #{video.description.truncate(30)}"
+  puts "  Thumbnail URL: #{video.thumbnail_url}"
+  puts "  Published at: #{video.published_at}"
+  puts "  Tags: #{video.tags}"
+  puts "  Channel ID: #{video.channel_id}"
+  puts "  Channel Title: #{video.channel_title}"
+  puts "  Category ID: #{video.category_id}"
+  puts "  Live content? #{video.live_broadcast_content}"
   puts "  Public? #{video.public?}"
   puts "  Views: #{video.view_count}"
   puts "  Comments: #{video.comment_count}"
   puts "  Likes: #{video.like_count}"
   puts "  Dislikes: #{video.dislike_count}"
   puts "  Favorites: #{video.favorite_count}"
-  puts "  hd? #{video.hd?}"
+  puts "  Duration: #{video.duration}s"
+  puts "  HD: #{video.hd?}"
   puts "  stereoscopic? #{video.stereoscopic?}"
   puts "  captioned? #{video.captioned?}"
   puts "  licensed? #{video.licensed?}"
+  # These are not available with a device auth :(
+  # puts "  Views: #{video.views}"
+  # puts "  Comments: #{video.comments}"
+  # puts "  Likes: #{video.likes}"
+  # puts "  Dislikes: #{video.dislikes}"
+  # puts "  Shares: #{video.shares}"
+  puts "  Annotations: #{video.annotations.count}"
+end
+
+account.playlists.first(5).each.with_index do |playlist, i|
+  puts "\nPLAYLIST #{i+1}:\n"
+  puts "  Title: #{playlist.title}"
+  puts "  Description: #{playlist.description.truncate(30)}"
+  puts "  Thumbnail URL: #{playlist.thumbnail_url}"
+  puts "  Published at: #{playlist.published_at}"
+  puts "  Tags: #{playlist.tags}"
+  puts "  Channel ID: #{playlist.channel_id}"
+  puts "  Channel Title: #{playlist.channel_title}"
+  puts "  Public? #{playlist.public?}"
+  puts "  Playlist items: #{playlist.playlist_items.count}"
+  playlist.playlist_items.first(5).each.with_index do |playlist_item, j|
+    puts "    \nPLAYLIST ITEM #{j+1}:\n"
+    puts "    Position: #{playlist_item.position + 1}"
+    puts "    Video ID: #{playlist_item.video_id}"
+  end
 end

--- a/lib/yt/associations/has_authentication.rb
+++ b/lib/yt/associations/has_authentication.rb
@@ -7,6 +7,7 @@ module Yt
     module HasAuthentication
       def has_authentication
         require 'yt/collections/authentications'
+        require 'yt/collections/device_flows'
         require 'yt/errors/missing_auth'
         require 'yt/errors/no_items'
         require 'yt/errors/unauthorized'
@@ -21,6 +22,7 @@ module Yt
       def initialize(options = {})
         @access_token = options[:access_token]
         @refresh_token = options[:refresh_token]
+        @device_code = options[:device_code]
         @expires_at = options[:expires_at]
         @authorization_code = options[:authorization_code]
         @redirect_uri = options[:redirect_uri]
@@ -35,6 +37,7 @@ module Yt
         @authentication = current_authentication
         @authentication ||= use_refresh_token! if @refresh_token
         @authentication ||= use_authorization_code! if @authorization_code
+        @authentication ||= use_device_code! if @device_code
         @authentication ||= raise_missing_authentication!
       end
 
@@ -84,13 +87,38 @@ module Yt
         raise Errors::Unauthorized, error.to_param
       end
 
+      # Tries to obtain an access token using the device code (which must be
+      # confirmed by the user with the user_code). On failure, raise an error.
+      def use_device_code!
+        device_code_authentications.first!.tap do |auth|
+          raise Errors::MissingAuth, pending_device_code_message if auth.pending?
+        end
+      end
+
       def raise_missing_authentication!
-        error = {}.tap do |params|
-          params[:authentication_url] = authentication_url
+        error_message = case
+          when @redirect_uri && @scopes then missing_authorization_code_message
+          when @scopes then pending_device_code_message
+        end
+        raise Errors::MissingAuth, error_message
+      end
+
+      def pending_device_code_message
+        @device_flow ||= device_flows.first!
+        @device_code ||= @device_flow.device_code
+        {}.tap do |params|
           params[:scopes] = @scopes
+          params[:user_code] = @device_flow.user_code
+          params[:verification_url] = @device_flow.verification_url
+        end
+      end
+
+      def missing_authorization_code_message
+        {}.tap do |params|
+          params[:scopes] = @scopes
+          params[:authentication_url] = authentication_url
           params[:redirect_uri] = @redirect_uri
         end
-        raise Errors::MissingAuth, error
       end
 
       def new_authentications
@@ -102,6 +130,18 @@ module Yt
       def refreshed_authentications
         @refreshed_authentications ||= Collections::Authentications.of(self).tap do |auth|
           auth.auth_params = refreshed_authentication_params
+        end
+      end
+
+      def device_code_authentications
+        Collections::Authentications.of(self).tap do |auth|
+          auth.auth_params = device_code_authentication_params
+        end
+      end
+
+      def device_flows
+        @device_flows ||= Collections::DeviceFlows.of(self).tap do |auth|
+          auth.auth_params = device_flow_params
         end
       end
 
@@ -138,6 +178,22 @@ module Yt
           params[:client_secret] = client_secret
           params[:refresh_token] = @refresh_token
           params[:grant_type] = :refresh_token
+        end
+      end
+
+      def device_code_authentication_params
+        {}.tap do |params|
+          params[:client_id] = client_id
+          params[:client_secret] = client_secret
+          params[:code] = @device_code
+          params[:grant_type] = 'http://oauth.net/grant_type/device/1.0'
+        end
+      end
+
+      def device_flow_params
+        {}.tap do |params|
+          params[:client_id] = client_id
+          params[:scope] = authentication_scope
         end
       end
 

--- a/lib/yt/associations/has_authentication.rb
+++ b/lib/yt/associations/has_authentication.rb
@@ -1,15 +1,20 @@
-require 'yt/collections/authentications'
-require 'yt/config'
-require 'yt/errors/no_items'
-require 'yt/errors/unauthorized'
-
 module Yt
-  module Modules
-    # Provides authentication methods to YouTube resources, which
-    # allows to access to content detail set-specific methods like `access_token`.
+  module Associations
+    # Provides authentication methods to YouTube resources, which allows to
+    # access to content detail set-specific methods like `access_token`.
     #
     # YouTube resources with authentication are: {Yt::Models::Account accounts}.
-    module Authentication
+    module HasAuthentication
+      def has_authentication
+        require 'yt/collections/authentications'
+        require 'yt/errors/no_items'
+        require 'yt/errors/unauthorized'
+
+        include Associations::Authenticable
+      end
+    end
+
+    module Authenticable
       delegate :access_token, :refresh_token, :expires_at, to: :authentication
 
       def initialize(options = {})

--- a/lib/yt/associations/has_many.rb
+++ b/lib/yt/associations/has_many.rb
@@ -1,32 +1,21 @@
-require 'active_support' # does not load anything by default but is required
-require 'active_support/core_ext/module/delegation' # for delegate
-require 'active_support/core_ext/string/inflections' # for camelize/constantize
-
 module Yt
-  module Modules
+  module Associations
     # Associations are a set of macro-like class methods to express
     # relationship between YouTube resources like "Channel has many Videos" or
     # "Account has one Id". They are inspired by ActiveRecord::Associations.
-    module Associations
+    module HasMany
       # @example Adds the +videos+ method to the Channel resource.
       #   class Channel < Resource
       #     has_many :videos
       #   end
       def has_many(attributes)
+        require 'active_support' # does not load anything by default
+        require 'active_support/core_ext/string/inflections' # for camelize ...
         require "yt/collections/#{attributes}"
+
         collection_name = attributes.to_s.sub(/.*\./, '').camelize.pluralize
         collection = "Yt::Collections::#{collection_name}".constantize
         define_memoized_method(attributes) { collection.of self }
-      end
-
-      # @example Adds the +status+ method to the Video resource.
-      #   class Video < Resource
-      #     has_one :status
-      #   end
-      def has_one(attribute)
-        attributes = attribute.to_s.pluralize
-        has_many attributes
-        define_memoized_method(attribute) { send(attributes).first! }
       end
 
     private

--- a/lib/yt/associations/has_one.rb
+++ b/lib/yt/associations/has_one.rb
@@ -1,0 +1,21 @@
+module Yt
+  module Associations
+    # Associations are a set of macro-like class methods to express
+    # relationship between YouTube resources like "Channel has many Videos" or
+    # "Account has one Id". They are inspired by ActiveRecord::Associations.
+    module HasOne
+      # @example Adds the +status+ method to the Video resource.
+      #   class Video < Resource
+      #     has_one :status
+      #   end
+      def has_one(attribute)
+        require 'yt/associations/has_many'
+        extend Associations::HasMany
+
+        attributes = attribute.to_s.pluralize
+        has_many attributes
+        define_memoized_method(attribute) { send(attributes).first! }
+      end
+    end
+  end
+end

--- a/lib/yt/associations/has_reports.rb
+++ b/lib/yt/associations/has_reports.rb
@@ -1,11 +1,10 @@
-require 'yt/collections/reports'
-
 module Yt
-  module Modules
+  module Associations
     # Provides methods to to access the analytics reports of a resource.
     #
-    # YouTube resources with reports are: {Yt::Models::Channel channels}.
-    module Reports
+    # YouTube resources with reports are: {Yt::Models::Channel channels} and
+    #  {Yt::Models::Channel videos}.
+    module HasReports
       # @!macro has_report
       #   @!method $1_on(date)
       #     @return [Float] the $1 for a single day.
@@ -26,6 +25,8 @@ module Yt
       #     has_report :earnings
       #   end
       def has_report(metric)
+        require 'yt/collections/reports'
+
         define_method "#{metric}_on" do |date|
           send(metric, from: date, to: date).values.first
         end

--- a/lib/yt/collections/device_flows.rb
+++ b/lib/yt/collections/device_flows.rb
@@ -1,0 +1,32 @@
+require 'yt/collections/base'
+require 'yt/models/device_flow'
+
+module Yt
+  module Collections
+    class DeviceFlows < Base
+      attr_accessor :auth_params
+
+    private
+
+      def new_item(data)
+        Yt::DeviceFlow.new data: data
+      end
+
+      def list_params
+        super.tap do |params|
+          params[:host] = 'accounts.google.com'
+          params[:path] = '/o/oauth2/device/code'
+          params[:body_type] = :form
+          params[:method] = :post
+          params[:auth] = nil
+          params[:body] = auth_params
+        end
+      end
+
+      def next_page
+        request = Yt::Request.new list_params
+        Array.wrap request.run.body
+      end
+    end
+  end
+end

--- a/lib/yt/errors/missing_auth.rb
+++ b/lib/yt/errors/missing_auth.rb
@@ -11,17 +11,19 @@ module Yt
         MSG
       end
 
-    private
-
       def more_details
         if scopes && authentication_url && redirect_uri
-          more_details_with_url
+          more_details_with_authentication_url
+        elsif scopes && user_code && verification_url
+          more_details_with_verification_url
         else
           more_details_without_url
         end
       end
 
-      def more_details_with_url
+    private
+
+      def more_details_with_authentication_url
         <<-MSG.gsub(/^ {8}/, '')
         You can ask YouTube accounts to authenticate your app for the scopes
         #{scopes} by directing them to #{authentication_url}.
@@ -31,6 +33,13 @@ module Yt
         to build an authorized account object by running:
 
         Yt::Account.new authorization_code: code, redirect_uri: "#{redirect_uri}"
+        MSG
+      end
+
+      def more_details_with_verification_url
+        <<-MSG.gsub(/^ {8}/, '')
+        Please authenticate your app by visiting the page #{verification_url}
+        and entering the code #{user_code} before continuing.
         MSG
       end
 
@@ -58,6 +67,14 @@ module Yt
 
       def redirect_uri
         @msg[:redirect_uri]
+      end
+
+      def user_code
+        @msg[:user_code]
+      end
+
+      def verification_url
+        @msg[:verification_url]
       end
     end
   end

--- a/lib/yt/errors/missing_auth.rb
+++ b/lib/yt/errors/missing_auth.rb
@@ -1,0 +1,64 @@
+require 'yt/errors/request_error'
+
+module Yt
+  module Errors
+    class MissingAuth < RequestError
+      def message
+        <<-MSG.gsub(/^ {8}/, '')
+        A request to YouTube API was sent without a valid authentication.
+
+        #{more_details}
+        MSG
+      end
+
+    private
+
+      def more_details
+        if scopes && authentication_url && redirect_uri
+          more_details_with_url
+        else
+          more_details_without_url
+        end
+      end
+
+      def more_details_with_url
+        <<-MSG.gsub(/^ {8}/, '')
+        You can ask YouTube accounts to authenticate your app for the scopes
+        #{scopes} by directing them to #{authentication_url}.
+
+        After they provide access to their account, they will be redirected to
+        #{redirect_uri} with a 'code' query parameter that you can read and use
+        to build an authorized account object by running:
+
+        Yt::Account.new authorization_code: code, redirect_uri: "#{redirect_uri}"
+        MSG
+      end
+
+      def more_details_without_url
+        <<-MSG.gsub(/^ {8}/, '')
+        If you know the access token of the YouTube you want to authenticate
+        with, build an authorized account object by running:
+
+        Yt::Account.new access_token: access_token
+
+        If you know the refresh token of the YouTube you want to authenticate
+        with, build an authorized account object by running:
+
+        Yt::Account.new refresh_token: refresh_token
+        MSG
+      end
+
+      def scopes
+        @msg[:scopes]
+      end
+
+      def authentication_url
+        @msg[:authentication_url]
+      end
+
+      def redirect_uri
+        @msg[:redirect_uri]
+      end
+    end
+  end
+end

--- a/lib/yt/errors/request_error.rb
+++ b/lib/yt/errors/request_error.rb
@@ -1,7 +1,7 @@
 module Yt
   module Errors
     class RequestError < StandardError
-      def initialize(msg = nil)
+      def initialize(msg = {})
         @msg = msg
         super msg
       end

--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -1,14 +1,10 @@
 require 'yt/models/base'
-require 'yt/modules/authentication'
 
 module Yt
   module Models
     # Provides methods to interact with YouTube accounts.
     # @see https://developers.google.com/youtube/v3/guides/authentication
     class Account < Base
-      # Includes methods to authenticate with YouTube API.
-      include Modules::Authentication
-
       # @!attribute [r] channel
       #   @return [Yt::Models::Channel] the account’s channel.
       has_one :channel
@@ -27,6 +23,8 @@ module Yt
       # @return [String] name of the CMS account, if the account is partnered.
       # @return [nil] if the account is not a partnered content owner.
       attr_reader :owner_name
+
+      has_authentication
 
       # @private
       # Tells `has_many :videos` that account.videos should return all the

--- a/lib/yt/models/authentication.rb
+++ b/lib/yt/models/authentication.rb
@@ -55,12 +55,18 @@ module Yt
       def initialize(data = {})
         @access_token = data['access_token']
         @refresh_token = data['refresh_token']
+        @error = data['error']
         @expires_at = expiration_date data.slice('expires_at', 'expires_in')
       end
 
       # @return [Boolean] whether the access token has expired.
       def expired?
         @expires_at && @expires_at.past?
+      end
+
+      # @return [Boolean] whether the device auth is pending
+      def pending?
+        @error == 'authorization_pending'
       end
 
     private

--- a/lib/yt/models/base.rb
+++ b/lib/yt/models/base.rb
@@ -1,15 +1,23 @@
 require 'yt/actions/delete'
 require 'yt/actions/update'
-require 'yt/modules/associations'
+
+require 'yt/associations/has_authentication'
+require 'yt/associations/has_many'
+require 'yt/associations/has_one'
+require 'yt/associations/has_reports'
+
 require 'yt/errors/request_error'
 
 module Yt
   module Models
     class Base
-      extend Modules::Associations
-
       include Actions::Delete
       include Actions::Update
+
+      extend Associations::HasReports
+      extend Associations::HasOne
+      extend Associations::HasMany
+      extend Associations::HasAuthentication
     end
   end
 

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -1,14 +1,10 @@
 require 'yt/models/resource'
-require 'yt/modules/reports'
 
 module Yt
   module Models
     # A channel resource contains information about a YouTube channel.
     # @see https://developers.google.com/youtube/v3/docs/channels
     class Channel < Resource
-      # Includes the +:has_report+ method to access YouTube Analytics reports.
-      extend Modules::Reports
-
       # @!attribute [r] subscriptions
       #   @return [Yt::Collections::Subscriptions] the channel’s subscriptions.
       has_many :subscriptions

--- a/lib/yt/models/device_flow.rb
+++ b/lib/yt/models/device_flow.rb
@@ -1,0 +1,23 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    class DeviceFlow < Base
+      def initialize(options = {})
+        @data = options[:data]
+      end
+
+      def device_code
+        @device_code ||= @data['device_code']
+      end
+
+      def user_code
+        @user_code ||= @data['user_code']
+      end
+
+      def verification_url
+        @verification_url ||= @data['verification_url']
+      end
+    end
+  end
+end

--- a/lib/yt/models/request.rb
+++ b/lib/yt/models/request.rb
@@ -159,11 +159,14 @@ module Yt
       # If a request authorized with an access token returns 401, then the
       # access token might have expired. If a refresh token is also present,
       # try to run the request one more time with a refreshed access token.
+      # If it's not present, then don't raise the returned MissingAuth, just
+      # let the original error bubble up.
       def refresh_token_and_retry?
         if response.is_a? Net::HTTPUnauthorized
-          @response = @http_request = @uri = nil
-          @auth.refresh
+          @auth.refresh.tap { @response = @http_request = @uri = nil }
         end if @auth.respond_to? :refresh
+      rescue Errors::MissingAuth
+        false
       end
 
       def response_error

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -1,14 +1,10 @@
 require 'yt/models/resource'
-require 'yt/modules/reports'
 
 module Yt
   module Models
     # Provides methods to interact with YouTube videos.
     # @see https://developers.google.com/youtube/v3/docs/videos
     class Video < Resource
-      # Includes the +:has_report+ method to access YouTube Analytics reports.
-      extend Modules::Reports
-
       delegate :tags, :channel_id, :channel_title, :category_id,
         :live_broadcast_content, to: :snippet
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.7.6'
+  VERSION = '0.7.7'
 end

--- a/spec/errors/missing_auth_spec.rb
+++ b/spec/errors/missing_auth_spec.rb
@@ -1,10 +1,24 @@
 require 'spec_helper'
-require 'yt/errors/unauthorized'
+require 'yt/errors/missing_auth'
 
-describe Yt::Errors::Unauthorized do
+describe Yt::Errors::MissingAuth do
+  subject(:error) { raise Yt::Errors::MissingAuth, params }
+  let(:params) { {} }
   let(:msg) { %r{^A request to YouTube API was sent without a valid authentication} }
 
   describe '#exception' do
-    it { expect{raise Yt::Errors::Unauthorized}.to raise_error msg }
+    it { expect{error}.to raise_error msg }
+
+    context 'given the user can authenticate via web' do
+      let(:params) { {scopes: 'youtube', authentication_url: 'http://google.example.com/auth', redirect_uri: 'http://localhost/'} }
+      let(:msg) { %r{^You can ask YouTube accounts to authenticate your app} }
+      it { expect{error}.to raise_error msg }
+    end
+
+    context 'given the user can authenticate via device code' do
+      let(:params) { {scopes: 'youtube', user_code: 'abcdefgh', verification_url: 'http://google.com/device'} }
+      let(:msg) { %r{^Please authenticate your app by visiting the page} }
+      it { expect{error}.to raise_error msg }
+    end
   end
 end

--- a/spec/errors/unauthorized_spec.rb
+++ b/spec/errors/unauthorized_spec.rb
@@ -1,0 +1,10 @@
+require 'spec_helper'
+require 'yt/errors/unauthorized'
+
+describe Yt::Errors::Unauthorized do
+  let(:msg) { %r{^A request to YouTube API was sent without a valid authentication} }
+
+  describe '#exception' do
+    it { expect{raise Yt::Errors::Unauthorized}.to raise_error msg }
+  end
+end

--- a/spec/requests/as_account/authentications_spec.rb
+++ b/spec/requests/as_account/authentications_spec.rb
@@ -65,7 +65,12 @@ describe Yt::Account, :device_app do
         context 'that has expired' do
           let(:expires_at) { 1.day.ago.to_s }
 
-          context 'and no valid refresh token' do
+          context 'and no refresh token' do
+            it { expect{account.authentication}.to raise_error Yt::Errors::MissingAuth }
+          end
+
+          context 'and an invalid refresh token' do
+            before { attrs[:refresh_token] = '--not-a-valid-refresh-token--' }
             it { expect{account.authentication}.to raise_error Yt::Errors::Unauthorized }
           end
 
@@ -80,7 +85,7 @@ describe Yt::Account, :device_app do
         let(:access_token) { '--not-a-valid-access-token--' }
         let(:expires_at) { 1.day.from_now }
 
-        context 'and no valid refresh token' do
+        context 'and no refresh token' do
           it { expect{account.channel}.to raise_error Yt::Errors::Unauthorized }
         end
 
@@ -93,7 +98,7 @@ describe Yt::Account, :device_app do
 
     context 'given no token or code' do
       let(:attrs) { {} }
-      it { expect{account.authentication}.to raise_error Yt::Errors::Unauthorized }
+      it { expect{account.authentication}.to raise_error Yt::Errors::MissingAuth }
     end
   end
 

--- a/spec/requests/as_account/authentications_spec.rb
+++ b/spec/requests/as_account/authentications_spec.rb
@@ -96,6 +96,25 @@ describe Yt::Account, :device_app do
       end
     end
 
+    context 'given scopes' do
+      let(:attrs) { {scopes: ['userinfo.email', 'youtube']} }
+
+      context 'and a redirect_uri' do
+        before { attrs[:redirect_uri] = 'http://localhost/' }
+
+        it { expect{account.authentication}.to raise_error Yt::Errors::MissingAuth }
+      end
+
+      context 'and no device token' do
+        it { expect{account.authentication}.to raise_error Yt::Errors::MissingAuth }
+      end
+
+      context 'and an invalid device code' do
+        before { attrs[:device_code] = '--not-a-valid-device-code--' }
+        it { expect{account.authentication}.to raise_error Yt::Errors::MissingAuth }
+      end
+    end
+
     context 'given no token or code' do
       let(:attrs) { {} }
       it { expect{account.authentication}.to raise_error Yt::Errors::MissingAuth }


### PR DESCRIPTION
It is now possible to use yt also for apps that authorize access to
YouTube through a device. The first request to authorize will fetch
a device code and a user token; once the user confirms the token in
a browser, the account is authorized.
