### PR TITLE
Make channel.videos access more than 500 videos

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.7.8)
+    yt (0.7.9)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -15,6 +15,7 @@ v0.7 - 2014/06/18
 * Allow both normal and partnered channels to retrieve reports about views, comments, likes, dislikes, shares
 * Make reports available also on Video (not just Channel)
 * New account.upload_video to upload a video (either local or remote).
+* Make channel.videos access more than 500 videos per channel
 
 v0.6 - 2014/06/05
 -----------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.7.8'
+    gem 'yt', '~> 0.7.9'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.7.8'
+  VERSION = '0.7.9'
 end

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -40,6 +40,15 @@ describe Yt::Channel, :device_app do
       it { expect(channel.subscribed?).to be true }
       it { expect(channel.unsubscribe!).to be_truthy }
     end
+
+    # NOTE: These tests are slow because they go through multiple pages of
+    # results and do so to test that we can overcome YouTube’s limitation of
+    # only returning the first 500 results for each query.
+    context 'with more than 500 videos' do
+      let(:id) { 'UCsmvakQZlvGsyjyOhmhvOsw' }
+      it { expect(channel.video_count).to be > 500 }
+      it { expect(channel.videos.count).to be > 500 }
+    end
   end
 
   context 'given my own channel' do


### PR DESCRIPTION
According to http://stackoverflow.com/a/23256768, YouTube API
won't provide more than ~500 search results for any arbitrary query.

This commit allows to overcome this limitation by splitting channel.videos
into multiple paginated queries that ask for videos in chronological order
and use the `publishedBefore` parameter to collect all the videos.

Closes #23
