### PR TITLE
Use Transfer-Encoding: chunked to upload videos

### DIFF
--- a/lib/yt/models/request.rb
+++ b/lib/yt/models/request.rb
@@ -60,9 +60,13 @@ module Yt
       end
 
       def set_headers!(request)
-        if @body_type == :json
+        case @body_type
+        when :json
           request.initialize_http_header 'Content-Type' => 'application/json'
           request.initialize_http_header 'Content-length' => '0' unless @body
+        when :file
+          request.initialize_http_header 'Content-Length' => @body.size.to_s
+          request.initialize_http_header 'Transfer-Encoding' => 'chunked'
         end
         @headers.each{|name, value| request.add_field name, value}
       end
@@ -84,7 +88,7 @@ module Yt
         case @body_type
           when :json then request.body = @body.to_json
           when :form then request.set_form_data @body
-          when :file then request.body = @body.read
+          when :file then request.body_stream = @body
         end if @body
       end
 


### PR DESCRIPTION
When using Net::HTTP to post a file, it is not necessary to read the
whole file and pass it as the request body. The `body_stream` option
can instead by using to upload the file in chunks.
