### PR TITLE
Add Claims#list and ClaimSearch#list

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Use [Yt::ContentOwner](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models
 
 * authenticate as a YouTube content owner
 * list the channels partnered with a YouTube content owner
+* list the claims administered by the content owner
+* search the claims administered by the content owner
 
 ```ruby
 # Content owners can be initialized with access token, refresh token or an authorization code
@@ -92,6 +94,8 @@ content_owner = Yt::ContentOwner.new owner_name: 'CMSname', access_token: 'ya29.
 
 content_owner.partnered_channels.count #=> 12
 content_owner.partnered_channels.first #=> #<Yt::Models::Channel @id=...>
+content_owner.claims.first #=> => #<Yt::Models::Claim ...>
+content_owner.claim_searches.where(videoId: 'dQw4w9WgXcQ,btPJPFnesV4').first #=> => #<Yt::Models::Claim ...>
 ```
 
 *All the above methods require authentication (see below).*

--- a/lib/yt.rb
+++ b/lib/yt.rb
@@ -1,6 +1,7 @@
 require 'yt/config'
 require 'yt/models/account'
 require 'yt/models/channel'
+require 'yt/models/claim'
 require 'yt/models/content_owner'
 require 'yt/models/playlist'
 require 'yt/models/playlist_item'

--- a/lib/yt/collections/claim_searches.rb
+++ b/lib/yt/collections/claim_searches.rb
@@ -1,0 +1,24 @@
+require 'yt/models/claim'
+
+module Yt
+  module Collections
+    class ClaimSearches < Base
+
+    private
+
+      def new_item(data)
+        Yt::Claim.new data: data
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to list claims that match the search criteria.
+      # @see https://developers.google.com/youtube/partner/docs/v1/claimSearch/list
+      def list_params
+        super.tap do |params|
+          params[:path] = "/youtube/partner/v1/claimSearch"
+          params[:params] = {onBehalfOfContentOwner: @parent.owner_name}.merge(@extra_params || {})
+        end
+      end
+      
+    end
+  end
+end

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -1,0 +1,24 @@
+require 'yt/models/claim'
+
+module Yt
+  module Collections
+    class Claims < Base
+
+    private
+
+      def new_item(data)
+        Yt::Claim.new data: data
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to list claims administered by the content owner.
+      # @see https://developers.google.com/youtube/partner/docs/v1/claims/list
+      def list_params
+        super.tap do |params|
+          params[:path] = "/youtube/partner/v1/claims"
+          params[:params] = {onBehalfOfContentOwner: @parent.owner_name}.merge(@extra_params || {})
+        end
+      end
+      
+    end
+  end
+end

--- a/lib/yt/models/claim.rb
+++ b/lib/yt/models/claim.rb
@@ -1,0 +1,56 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    class Claim < Base
+      def initialize(options = {})
+        @data = options[:data]
+      end
+
+      def id
+        @data["id"]
+      end
+
+      def asset_id
+        @data["assetId"]
+      end
+
+      def video_id
+        @data["videoId"]
+      end
+
+      def status
+        @data["status"]
+      end
+
+      def policy
+        @data["policy"]
+      end
+
+      def content_type
+        @data["contentType"]
+      end
+
+      def time_created
+        @data["timeCreated"]
+      end
+
+      def block_outside_ownership
+        @data["blockOutsideOwnership"]
+      end
+
+      def origin
+        @data["origin"]
+      end
+
+      def video_views
+        @data["videoViews"]
+      end
+
+      def video_title
+        @data["videoTitle"]
+      end
+
+    end
+  end
+end

--- a/lib/yt/models/content_owner.rb
+++ b/lib/yt/models/content_owner.rb
@@ -11,6 +11,14 @@ module Yt
       #   @return [Yt::Collection::PartneredChannels] the channels managed by the CMS account.
       has_many :partnered_channels
 
+      # @!attribute [r] claims
+      #   @return [Yt::Collection::Claim] the claims administered by the content owner.
+      has_many :claims
+
+      # @!attribute [r] claim_searches
+      #   @return [Yt::Collection::ClaimSearches] the claims that match search criteria.
+      has_many :claim_searches
+
       def initialize(options = {})
         super options
         @owner_name = options[:owner_name]

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -5,4 +5,6 @@ describe Yt::ContentOwner, :partner do
   # NOTE: Uncomment once size does not runs through *all* the pages
   # it { expect($content_owner.partnered_channels.size).to be > 0 }
   it { expect($content_owner.partnered_channels.first).to be_a Yt::Channel }
+  it { expect($content_owner.claims.first).to be_a Yt::Claim }
+  it { expect($content_owner.claim_searches.where(status: 'active').first).to be_a Yt::Claim }
 end


### PR DESCRIPTION
Adds the functionality to list Claims, and search for Claims.

https://developers.google.com/youtube/partner/docs/v1/claims/list

https://developers.google.com/youtube/partner/docs/v1/claimSearch/list

The way we handle attribute assignment is slightly different between each model class.  Some assign to instance variables, some don't.  I just kept this in line with some other models, but I could see some room for improvement on the claim attributes.

Thoughts?
