### PR TITLE
Add account.content_owners to list Content Owners

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.8.2)
+    yt (0.8.3)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -5,6 +5,7 @@ v0.8 - 2014/07/18
 * Add all the status fields to Video (upload status, failure reason, rejection reason, scheduled time, license, embeddable, public stats viewable)
 * Add content_owner.claims to list the claims administered by a content owner.
 * Allow content_owner.claims to be chained with .where, such as in account.videos.where(q: 'query')
+* Add account.content_owners to list content owners associated with an account
 
 v0.7 - 2014/06/18
 -----------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.8.2'
+    gem 'yt', '~> 0.8.3'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)
@@ -76,7 +76,16 @@ account.upload_video 'my_video.mp4', title: 'My new video', privacy_status: 'pri
 account.upload_video 'http://example.com/remote.m4v', title: 'My other video', tags: ['music']
 ```
 
-*All the above methods require authentication (see below).*
+*The methods above require to be authenticated as a YouTube account (see below).*
+
+```ruby
+account = Yt::Account.new access_token: 'ya29.1.ABCDEFGHIJ'
+
+account.content_owners.count #=> 3
+account.content_owners.first #=>  #<Yt::Models::ContentOwner @id=...>
+```
+
+*The methods above require to be authenticated as a YouTube Content Partner account (see below).*
 
 Yt::ContentOwner
 ----------------

--- a/lib/yt/associations/has_authentication.rb
+++ b/lib/yt/associations/has_authentication.rb
@@ -27,6 +27,7 @@ module Yt
         @authorization_code = options[:authorization_code]
         @redirect_uri = options[:redirect_uri]
         @scopes = options[:scopes]
+        @authentication = options[:authentication]
       end
 
       def auth

--- a/lib/yt/collections/content_owners.rb
+++ b/lib/yt/collections/content_owners.rb
@@ -1,0 +1,32 @@
+require 'yt/collections/base'
+require 'yt/models/content_owner'
+
+module Yt
+  module Collections
+    # Provides methods to interact with a collection of Content Owners.
+    #
+    # Resources with content_owners are: {Yt::Models::Account accounts}.
+    class ContentOwners < Base
+
+    private
+
+      def new_item(data)
+        Yt::ContentOwner.new owner_name: data['id'], authentication: @auth.authentication
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to list content
+      #   owners administered by the account.
+      # @see https://developers.google.com/youtube/partner/docs/v1/contentOwners/list
+      def list_params
+        super.tap do |params|
+          params[:params] = content_owners_params
+          params[:path] = '/youtube/partner/v1/contentOwners'
+        end
+      end
+
+      def content_owners_params
+        {fetchMine: true}
+      end
+    end
+  end
+end

--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -32,6 +32,11 @@ module Yt
       #     upload videos using the resumable upload protocol.
       has_many :resumable_sessions
 
+      # @!attribute [r] content_owners
+      #   @return [Yt::Collections::ContentOwners] the content_owners accessible
+      #     by the account.
+      has_many :content_owners
+
       # Uploads a video
       # @param [String] path_or_url the video to upload. Can either be the
       #   path of a local file or the URL of a remote file.

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.8.2'
+  VERSION = '0.8.3'
 end

--- a/spec/requests/as_content_owner/account_spec.rb
+++ b/spec/requests/as_content_owner/account_spec.rb
@@ -1,0 +1,25 @@
+# encoding: UTF-8
+require 'spec_helper'
+require 'yt/models/account'
+
+describe Yt::Account, :partner do
+  subject(:account) { Yt::Account.new id: id, authentication: $content_owner.authentication }
+
+  describe '.content_owners' do
+    let(:content_owners) { account.content_owners }
+
+    context 'given a partenered account with content owners', :partner do
+      let(:id) { $content_owner.id }
+
+      specify 'returns the associated content owners' do
+        expect(content_owners.size).to be > 0
+        expect(content_owners.first).to be_a Yt::ContentOwner
+      end
+
+      specify 'ensures the content owners have the same credentials as the account' do
+        expect(content_owners.first.access_token).to eq account.access_token
+        expect(content_owners.first.refresh_token).to eq account.refresh_token
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add account.content_owners to list Content Owners for an account

A new ContentOwner collection class is introduced to list Content Owners.
See https://developers.google.com/youtube/partner/docs/v1/contentOwners/list

``` ruby
yt_account.content_owners.count
  => 3
yt_account.content_owners.map &:id
  => ["cms_name_1", "cms_name_2", ...]
```
