### PR TITLE
[Discussion] #include method on base collection

### DIFF
--- a/lib/yt/collections/base.rb
+++ b/lib/yt/collections/base.rb
@@ -13,6 +13,8 @@ module Yt
       def initialize(options = {})
         @parent = options[:parent]
         @auth = options[:auth]
+        @extra_params = {}
+        @extra_parts = []
       end
 
       def self.of(parent)
@@ -22,6 +24,12 @@ module Yt
       def where(conditions = {})
         @items = []
         @extra_params = conditions
+        self
+      end
+
+      def include(*parts)
+        @items = []
+        @extra_parts = parts
         self
       end
     end

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -28,7 +28,7 @@ module Yt
 
       def claims_params
         {onBehalfOfContentOwner: @parent.owner_name}.tap do |params|
-          (@extra_params ||= {}).each do |key, value|
+          @extra_params.each do |key, value|
             params[key.to_s.camelize :lower] = value
           end
         end

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -15,7 +15,7 @@ module Yt
       #   the items returned by asking YouTube for a list of videos.
       # @see https://developers.google.com/youtube/v3/docs/videos#resource
       def new_item(data)
-        Yt::Video.new id: data['id']['videoId'], snippet: data['snippet'], auth: @auth
+        Yt::Video.new id: data['id']['videoId'], snippet: data['snippet'], statistics: data['statistics'], auth: @auth
       end
 
       # @return [Hash] the parameters to submit to YouTube to list videos.
@@ -23,7 +23,7 @@ module Yt
       def list_params
         super.tap do |params|
           params[:params] = @parent.videos_params.merge videos_params
-          params[:path] = '/youtube/v3/search'
+          params[:path] = videos_path
         end
       end
 
@@ -43,10 +43,21 @@ module Yt
       end
 
       def videos_params
-        params = {type: :video, maxResults: 50, part: 'snippet', order: 'date'}
+        params = {type: :video, maxResults: 50, part: videos_parts, order: 'date'}
         params[:publishedBefore] = @published_before if @published_before
-        @extra_params ||= {}
         params.merge @extra_params
+      end
+
+      def videos_path
+        if @extra_params.empty? || @extra_params.key?(:id)
+          '/youtube/v3/videos'
+        else
+          '/youtube/v3/search'
+        end
+      end
+
+      def videos_parts
+        [:snippet].concat(@extra_parts).uniq.join(',')
       end
     end
   end

--- a/lib/yt/models/resource.rb
+++ b/lib/yt/models/resource.rb
@@ -20,6 +20,7 @@ module Yt
         @auth = options[:auth]
         @snippet = Snippet.new(data: options[:snippet]) if options[:snippet]
         @status = Status.new(data: options[:status]) if options[:status]
+        @statistics_set = StatisticsSet.new(data: options[:statistics]) if options[:statistics]
       end
 
       def kind


### PR DESCRIPTION
Throwing this out there for discussion...  I'm going to need to make _a lot_ of API calls to get the view_counts and such of videos, and I'd like a way to do that as efficiently as possible (both time and quota).

Each call to the API is one additional quota unit, as well as ~300ms waiting.  Through `yt` there is no way to do this in bulk yet.

This PR would allow me to get the statistics of batched videos.

What do you think about adding an `include` method to specify additional parts?

``` ruby
Yt::Collections::Videos.new.include(:statistics, :content_owner_details).where(id: 'K9XCKP9KN7A').first
```
