### PR TITLE
Fix annotation timestamp parsing when t='0'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.8.3)
+    yt (0.8.4)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.8.3'
+    gem 'yt', '~> 0.8.4'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/models/annotation.rb
+++ b/lib/yt/models/annotation.rb
@@ -113,6 +113,7 @@ module Yt
 
       def timestamp_of(position)
         regex = %r{(?:|(?<hours>\d*):)(?:|(?<min>\d*):)(?<sec>\d*)\.(?<ms>\d*)}
+        position['t'] = '00:00:00.000' if position['t'] == '0'
         match = position['t'].match regex
         hours = (match[:hours] || '0').to_i
         minutes = (match[:min] || '0').to_i

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.8.3'
+  VERSION = '0.8.4'
 end

--- a/spec/models/annotation_spec.rb
+++ b/spec/models/annotation_spec.rb
@@ -157,5 +157,17 @@ describe Yt::Annotation do
       it { expect(annotation.starts_after? 0).to be_nil }
       it { expect(annotation.starts_before? 0).to be_nil }
     end
+
+    context 'given an annotation with "0" as the timestamp' do
+      let(:xml) { %Q{
+        <segment>
+        <movingRegion type="rect">
+        <rectRegion h="6.0" t="0" w="25.0" x="7.0" y="5.0"/>
+        </movingRegion>
+        </segment>
+      } }
+      it { expect(annotation.starts_after? 10).to be_falsey }
+      it { expect(annotation.starts_before? 10).to be true }
+    end
   end
 end


### PR DESCRIPTION
Some videos like https://www.youtube.com/watch?v=Qs1kvYr_EiE
have the timestamp in the format `t="0"` which differs from the
common form `t="00:00:00.000"`, so a special `if` statement is
needed to parse those annotations as well.
