### PR TITLE
Pass 'approval_prompt' and 'prompt' parameters to authorization server

### DIFF
--- a/lib/yt/associations/has_authentication.rb
+++ b/lib/yt/associations/has_authentication.rb
@@ -24,6 +24,8 @@ module Yt
         @refresh_token = options[:refresh_token]
         @device_code = options[:device_code]
         @expires_at = options[:expires_at]
+        @approval_prompt = options[:approval_prompt]
+        @prompt = options[:prompt]
         @authorization_code = options[:authorization_code]
         @redirect_uri = options[:redirect_uri]
         @scopes = options[:scopes]
@@ -150,6 +152,8 @@ module Yt
         {}.tap do |params|
           params[:client_id] = client_id
           params[:scope] = authentication_scope
+          params[:approval_prompt] = @approval_prompt if @approval_prompt
+          params[:prompt] = @prompt if @prompt
           params[:redirect_uri] = @redirect_uri
           params[:response_type] = :code
           params[:access_type] = :offline


### PR DESCRIPTION
Refresh tokens are not granted on subsequent oauth attempts unless consent is manually given

This allows for the following:

``` ruby

@url = Yt::Account.new(approval_prompt: 'force', scopes: ['userinfo.email'], redirect_uri: callback_url).authentication_url
@url = Yt::Account.new(prompt: 'consent', scopes: ['userinfo.email'], redirect_uri: callback_url).authentication_url
```

This supports both types of approval prompts,
- `approval_prompt` - either **force** or **auto** (docs: https://developers.google.com/youtube/2.0/developers_guide_protocol_oauth2)
- `prompt` - a space deliminated list of **none**, **consent**, **select_account** (docs: https://developers.google.com/accounts/docs/OAuth2Login#re-consent)
