### PR TITLE
Rename rating.update to rating.set

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.8.5)
+    yt (0.9.0)
       activesupport
 
 GEM
@@ -21,29 +21,27 @@ GEM
       thor
     diff-lcs (1.2.5)
     docile (1.1.5)
-    i18n (0.6.11)
+    i18n (0.6.9)
     json (1.8.1)
     mime-types (2.3)
-    minitest (5.4.0)
+    minitest (5.3.5)
     multi_json (1.10.1)
-    netrc (0.7.7)
     rake (10.3.2)
-    rest-client (1.7.2)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+    rest-client (1.6.7)
+      mime-types (>= 1.16)
     rspec (3.0.0)
       rspec-core (~> 3.0.0)
       rspec-expectations (~> 3.0.0)
       rspec-mocks (~> 3.0.0)
-    rspec-core (3.0.3)
+    rspec-core (3.0.2)
       rspec-support (~> 3.0.0)
-    rspec-expectations (3.0.3)
+    rspec-expectations (3.0.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.0.0)
-    rspec-mocks (3.0.3)
+    rspec-mocks (3.0.2)
       rspec-support (~> 3.0.0)
-    rspec-support (3.0.3)
-    simplecov (0.9.0)
+    rspec-support (3.0.2)
+    simplecov (0.8.2)
       docile (~> 1.1.0)
       multi_json
       simplecov-html (~> 0.8.0)

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,8 @@
+v0.9 - 2014/07/28
+-----------------
+
+* [breaking change] Rename rating.update to rating.set
+
 v0.8 - 2014/07/18
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.8.5'
+    gem 'yt', '~> 0.9.0'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/models/rating.rb
+++ b/lib/yt/models/rating.rb
@@ -16,7 +16,7 @@ module Yt
         @auth = options[:auth]
       end
 
-      def update(new_rating)
+      def set(new_rating)
         do_update(params: {rating: new_rating}) {@rating = new_rating}
       end
 

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -115,7 +115,7 @@ module Yt
       # @raise [Yt::Errors::Unauthorized] if {Resource#auth auth} does not
       #   return an authenticated account.
       def like
-        rating.update :like
+        rating.set :like
         liked?
       end
 
@@ -127,7 +127,7 @@ module Yt
       # @raise [Yt::Errors::Unauthorized] if {Resource#auth auth} does not
       #   return an authenticated account.
       def dislike
-        rating.update :dislike
+        rating.set :dislike
         !liked?
       end
 
@@ -139,7 +139,7 @@ module Yt
       # @raise [Yt::Errors::Unauthorized] if {Resource#auth auth} does not
       #   return an authenticated account.
       def unlike
-        rating.update :none
+        rating.set :none
         !liked?
       end
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.8.5'
+  VERSION = '0.9.0'
 end

--- a/spec/models/rating_spec.rb
+++ b/spec/models/rating_spec.rb
@@ -7,6 +7,6 @@ describe Yt::Rating do
   describe '#update' do
     before { expect(rating).to receive(:do_update).and_yield }
 
-    it { expect{rating.update :like}.to change{rating.rating} }
+    it { expect{rating.set :like}.to change{rating.rating} }
   end
 end


### PR DESCRIPTION
In order to have a coherent .update methods on all the resources,
and to have it accept a hash of options, Rating#update is renamed
to Rating#set since it does not accept a hash, but instead it accepts
the exact value to set the rating to.
