### PR TITLE
Allow status parameters of a video to be updated.

### DIFF
--- a/lib/yt/models/playlist.rb
+++ b/lib/yt/models/playlist.rb
@@ -24,22 +24,7 @@ module Yt
       end
 
       def update(attributes = {})
-        underscore_keys! attributes
-
-        body = {id: @id}.tap do |body|
-          update_parts.each do |part, options|
-            if (options[:keys] & attributes.keys).any? || options[:required]
-              body[part] = {}.tap do |hash|
-                options[:keys].map do |key|
-                  hash[camelize key] = attributes[key] || send(key)
-                end
-              end
-            end
-          end
-        end
-
-        part = body.except(:id).keys.join(',')
-        do_update(params: {part: part}, body: body) do |data|
+        super attributes do |data|
           @id = data['id']
           @snippet = Snippet.new data: data['snippet'] if data['snippet']
           @status = Status.new data: data['status'] if data['status']
@@ -86,18 +71,6 @@ module Yt
         snippet = {keys: [:title, :description, :tags], required: true}
         status = {keys: [:privacy_status]}
         {snippet: snippet, status: status}
-      end
-
-      # @note If we dropped support for ActiveSupport 3, then we could simply
-      # invoke transform_keys!{|key| key.to_s.underscore.to_sym}
-      def underscore_keys!(hash)
-        hash.dup.each_key do |key|
-          hash[key.to_s.underscore.to_sym] = hash.delete key
-        end
-      end
-
-      def camelize(value)
-        value.to_s.camelize(:lower).to_sym
       end
 
       def video_params(video_id)

--- a/lib/yt/models/status.rb
+++ b/lib/yt/models/status.rb
@@ -249,6 +249,7 @@ module Yt
       def scheduled_at
         @scheduled_at ||= Time.parse @data['publishAt'] if scheduled?
       end
+      alias publish_at scheduled_at
 
       # Returns whether the video is scheduled to be published.
       # @return [Boolean] if the resource is a video, whether it is currently
@@ -295,6 +296,7 @@ module Yt
       def embeddable?
         @embeddable ||= @data['embeddable']
       end
+      alias embeddable embeddable?
 
 # Public stats (Video only)
 
@@ -308,6 +310,7 @@ module Yt
       def has_public_stats_viewable?
         @public_stats_viewable ||= @data['publicStatsViewable']
       end
+      alias public_stats_viewable has_public_stats_viewable?
 
     private
 


### PR DESCRIPTION
Previously Video#update could only update snippet parameters such
as title, description. After this commit, status parameters can be
updated as well.

Unfortunately, YouTube does not let users update most of the status
parameters through the API: only privacyStatus, publicStatsViewable
and publishAt can indeed be updated.

This commit also extracts the commonality between the `update`
methods of Video and Playlist into a `Resource#update` method.
