### PR TITLE
Add channel.content_owner_details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.9.8 - 2014-08-11
+
+* [FEATURE] Add `.content_owner` and `.linked_at` to channels managed by a CMS content owner
+
 ## 0.9.7 - 2014-08-02
 
 * [BUGFIX] Correctly parse videos’ duration for videos longer than 24 hours

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.9.7)
+    yt (0.9.8)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.9.7'
+    gem 'yt', '~> 0.9.8'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)
@@ -194,6 +194,9 @@ channel.impressions_on 5.days.ago #=> 157.0
 
 channel.viewer_percentages #=> {female: {'18-24' => 12.12, '25-34' => 16.16,…}…}
 channel.viewer_percentage(gender: :female) #=> 49.12
+
+channel.content_owner #=> 'FullScreen'
+channel.linked_at #=> Wed, 28 May 2014
 ```
 
 *The methods above require to be authenticated as the channel’s content owner (see below).*

--- a/lib/yt/collections/content_owner_details.rb
+++ b/lib/yt/collections/content_owner_details.rb
@@ -1,0 +1,36 @@
+require 'yt/collections/base'
+require 'yt/models/content_owner_detail'
+
+module Yt
+  module Collections
+    class ContentOwnerDetails < Base
+
+    private
+
+      # @return [Yt::Models::ContentOwnerDetail] a new content detail
+      #   initialized with one of the items returned by asking YouTube for a
+      #   list of them.
+      def new_item(data)
+        Yt::ContentOwnerDetail.new data: data['contentOwnerDetails']
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to get the
+      #   content owner detail of a channel.
+      # @see https://developers.google.com/youtube/v3/docs/channels#contentOwnerDetails
+      def list_params
+        super.tap do |params|
+          params[:params] = content_owner_details_params
+          params[:path] = '/youtube/v3/channels'
+        end
+      end
+
+      def content_owner_details_params
+        @parent.content_owner_details_params.tap do |params|
+          params[:max_results] = 50
+          params[:part] = 'contentOwnerDetails'
+          params[:id] = @parent.id
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -47,6 +47,12 @@ module Yt
       delegate :view_count, :comment_count, :video_count, :subscriber_count,
         :subscriber_count_visible?, to: :statistics_set
 
+      # @!attribute [r] content_owner_detail
+      #   @return [Yt::Models::ContentOwnerDetail] the video’s content owner
+      #     details.
+      has_one :content_owner_detail
+      delegate :content_owner, :linked_at, to: :content_owner_detail
+
       # Returns whether the authenticated account is subscribed to the channel.
       #
       # This method requires {Resource#auth auth} to return an
@@ -134,6 +140,15 @@ module Yt
             params['ids'] = "channel==#{id}"
           end
         end
+      end
+
+      # @private
+      # Tells `has_one :content_owner_detail` to retrieve the content owner
+      # detail as the Content Owner, it the channel was authorized with one.
+      # If it was not, the call will fail, since YouTube only allows content
+      # owners to check who is the content owner of a channel.
+      def content_owner_details_params
+        {on_behalf_of_content_owner: auth.owner_name || auth.id}
       end
     end
   end

--- a/lib/yt/models/content_owner_detail.rb
+++ b/lib/yt/models/content_owner_detail.rb
@@ -1,0 +1,47 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # Encapsulates channel data that is relevant for YouTube Partners linked
+    # with the channel.
+    # @see https://developers.google.com/youtube/v3/docs/channels#contentOwnerDetails
+    class ContentOwnerDetail < Base
+      def initialize(options = {})
+        @data = options[:data] || {}
+      end
+
+      # Returns the name of the content owner linked to the channel.
+      #
+      # This method requires {Resource#auth auth} to return an authenticated
+      # instance of {Yt::ContentOwner} that can administer the channel.
+      # @return [String] if the channel is partnered with a content owner,
+      #   the name of the content owner linked to the channel.
+      # @return [nil] if the channel is not partnered with a content owner.
+      # @return [nil] if {Resource#auth auth} is a content owner without
+      #   permissions to administer the channel.
+      # @raise [Yt::Errors::Forbidden] if {Resource#auth auth} does not
+      #   return an authenticated content owner.
+      def content_owner
+        @content_owner ||= @data['contentOwner']
+      end
+
+      # Returns the date and time of when the channel was linked to the content
+      # owner.
+      #
+      # This method requires {Resource#auth auth} to return an authenticated
+      # instance of {Yt::ContentOwner} that can administer the channel.
+      # @return [Time] if the channel is partnered with a content owner,
+      #   the date and time when the channel was linked with the content owner.
+      # @return [nil] if the channel is not partnered with a content owner.
+      # @return [nil] if {Resource#auth auth} is a content owner without
+      #   permissions to administer the channel.
+      # @raise [Yt::Errors::Forbidden] if {Resource#auth auth} does not
+      #   return an authenticated content owner.
+      def linked_at
+        @linked_at ||= if @data['timeLinked']
+          Time.parse @data['timeLinked']
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.9.7'
+  VERSION = '0.9.8'
 end

--- a/spec/models/content_owner_detail_spec.rb
+++ b/spec/models/content_owner_detail_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+require 'yt/models/content_owner_detail'
+
+describe Yt::ContentOwnerDetail do
+  subject(:content_owner_detail) { Yt::ContentOwnerDetail.new data: data }
+
+  describe '#content_owner' do
+    context 'given a content_owner_detail with a content owner' do
+      let(:data) { {"contentOwner"=>"FullScreen"} }
+      it { expect(content_owner_detail.content_owner).to eq 'FullScreen' }
+    end
+
+    context 'given a content_owner_detail without a content owner' do
+      let(:data) { {} }
+      it { expect(content_owner_detail.content_owner).to be_nil }
+    end
+  end
+
+  describe '#linked_at' do
+    context 'given a content_owner_detail with a timeLinked' do
+      let(:data) { {"timeLinked"=>"2014-04-22T19:14:49.000Z"} }
+      it { expect(content_owner_detail.linked_at.year).to be 2014 }
+    end
+
+    context 'given a content_owner_detail with a timeLinked' do
+      let(:data) { {} }
+      it { expect(content_owner_detail.linked_at).to be_nil }
+    end
+  end
+end

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -105,6 +105,11 @@ describe Yt::Channel, :device_app do
       expect{channel.viewer_percentages}.not_to raise_error
       expect{channel.viewer_percentage}.not_to raise_error
     end
+
+    it 'cannot give information about its content owner' do
+      expect{channel.content_owner}.to raise_error Yt::Errors::Forbidden
+      expect{channel.linked_at}.to raise_error Yt::Errors::Forbidden
+    end
   end
 
   context 'given an unknown channel' do

--- a/spec/requests/as_content_owner/channel_spec.rb
+++ b/spec/requests/as_content_owner/channel_spec.rb
@@ -263,13 +263,25 @@ describe Yt::Channel, :partner do
         expect(channel.viewer_percentage(gender: :male)).to be_a Float
         expect(channel.viewer_percentage(gender: :female)).to be_a Float
       end
+
+      specify 'information about its content owner can be retrieved' do
+        expect(channel.content_owner).to be_a String
+        expect(channel.linked_at).to be_a Time
+      end
     end
 
     context 'not managed by the authenticated Content Owner' do
       let(:id) { 'UCBR8-60-B28hp2BmDPdntcQ' }
 
-      it { expect{channel.earnings}.to raise_error Yt::Errors::Forbidden }
-      it { expect{channel.views}.to raise_error Yt::Errors::Forbidden }
+      specify 'earnings and impressions cannot be retrieved' do
+        expect{channel.earnings}.to raise_error Yt::Errors::Forbidden
+        expect{channel.views}.to raise_error Yt::Errors::Forbidden
+      end
+
+      specify 'information about its content owner cannot be retrieved' do
+        expect(channel.content_owner).to be_nil
+        expect(channel.linked_at).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
The easiest way to confirm that a channel is in a particular network is by checking the content_owner_details of that channel.  The content owner details object is **only accessible** if you are the content owner.

https://developers.google.com/youtube/v3/docs/channels#contentOwnerDetails

``` ruby
content_owner = Yt::ContentOwner.new(access_token: "...", owner_name: "FullScreen")

# channel in FullScreen
channel = Yt::Channel.new(id: 'UC-Z3Pey219Tyr9aW1mX7HQQ', auth: content_owner)
channel.content_owner => "FullScreen"
channel.time_linked => 2013-03-14 01:14:54 UTC

# channel not in FullScreen
channel = Yt::Channel.new(id: 'UCcMTZY1rFXO3Rj44D5VMyiw', auth: content_owner)
channel.content_owner => nil
channel.time_linked => nil
```

Thoughts?
