### PR TITLE
Update accepts both underscore and camelcase

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@ v0.9 - 2014/07/28
 * [breaking change] Rename rating.update to rating.set
 * Add content_owner.references to retrieve ContentID references
 * Add content_owner.policies to list ContentID policies
+* Let 'update' methods understand both under_score and camelCased parameters
 
 
 v0.8 - 2014/07/18

--- a/lib/yt/models/playlist.rb
+++ b/lib/yt/models/playlist.rb
@@ -24,22 +24,7 @@ module Yt
       end
 
       def update(attributes = {})
-        underscore_keys! attributes
-
-        body = {id: @id}.tap do |body|
-          update_parts.each do |part, options|
-            if (options[:keys] & attributes.keys).any? || options[:required]
-              body[part] = {}.tap do |hash|
-                options[:keys].map do |key|
-                  hash[camelize key] = attributes[key] || send(key)
-                end
-              end
-            end
-          end
-        end
-
-        part = body.except(:id).keys.join(',')
-        do_update(params: {part: part}, body: body) do |data|
+        super attributes do |data|
           @id = data['id']
           @snippet = Snippet.new data: data['snippet'] if data['snippet']
           @status = Status.new data: data['status'] if data['status']
@@ -86,18 +71,6 @@ module Yt
         snippet = {keys: [:title, :description, :tags], required: true}
         status = {keys: [:privacy_status]}
         {snippet: snippet, status: status}
-      end
-
-      # @note If we dropped support for ActiveSupport 3, then we could simply
-      # invoke transform_keys!{|key| key.to_s.underscore.to_sym}
-      def underscore_keys!(hash)
-        hash.dup.each_key do |key|
-          hash[key.to_s.underscore.to_sym] = hash.delete key
-        end
-      end
-
-      def camelize(value)
-        value.to_s.camelize(:lower).to_sym
       end
 
       def video_params(video_id)

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -81,20 +81,14 @@ module Yt
       #   caution, as the whole status object needs to be updated, not just
       #   privacyStatus, but also embeddable, license, publicStatsViewable,
       #   and publishAt
-      def update(options = {})
-        options[:title] ||= title
-        options[:description] ||= description
-        options[:tags] ||= tags
-        options[:categoryId] ||= category_id
-        snippet = options.slice :title, :description, :tags, :categoryId
-        body = {id: @id, snippet: snippet}
-
-        do_update(params: {part: 'snippet'}, body: body) do |data|
+      def update(attributes = {})
+        super attributes do |data|
           @id = data['id']
           @snippet = Snippet.new data: data['snippet'] if data['snippet']
           true
         end
       end
+
 
       # Returns whether the authenticated account likes the video.
       #
@@ -156,6 +150,15 @@ module Yt
           end
           params['filters'] = "video==#{id}"
         end
+      end
+
+    private
+
+      # @see https://developers.google.com/youtube/v3/docs/videos/update
+      # @todo: Add status, recording details keys
+      def update_parts
+        snippet_keys = [:title, :description, :tags, :category_id]
+        {snippet: {keys: snippet_keys}}
       end
     end
   end

--- a/spec/requests/as_account/account_spec.rb
+++ b/spec/requests/as_account/account_spec.rb
@@ -12,7 +12,7 @@ describe Yt::Account, :device_app do
 
   describe '.videos' do
     it { expect($account.videos).to be_a Yt::Collections::Videos }
-    it { expect($account.videos.first).to be_a Yt::Video }
+    it { expect($account.videos.where(order: 'viewCount').first).to be_a Yt::Video }
 
     describe '.where(q: query_string)' do
       let(:count) { $account.videos.where(q: query).count }

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -101,23 +101,69 @@ describe Yt::Video, :device_app do
 
   context 'given one of my own videos that I want to update' do
     let(:id) { $account.videos.first.id }
+    let!(:old_title) { video.title }
+    let!(:old_privacy_status) { video.privacy_status }
+    let(:update) { video.update attrs }
 
-    describe 'updates the attributes that I specify explicitly' do
+    context 'given I update the title' do
       # NOTE: The use of UTF-8 characters is to test that we can pass up to
       # 50 characters, independently of their representation
       let(:attrs) { {title: "Yt Example Update Video #{rand} - ®•♡❥❦❧☙"} }
-      it { expect(video.update attrs).to eq true }
-      it { expect{video.update attrs}.to change{video.title} }
+
+      specify 'only updates the title' do
+        expect(update).to be true
+        expect(video.title).not_to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
     end
 
-    describe 'does not update the other attributes' do
-      let(:attrs) { {} }
-      it { expect(video.update attrs).to eq true }
-      it { expect{video.update attrs}.not_to change{video.title} }
-      it { expect{video.update attrs}.not_to change{video.description} }
-      it { expect{video.update attrs}.not_to change{video.tags} }
-      it { expect{video.update attrs}.not_to change{video.category_id} }
-      it { expect{video.update attrs}.not_to change{video.privacy_status} }
+    context 'given I update the description' do
+      let!(:old_description) { video.description }
+      let(:attrs) { {description: "Yt Example Description  #{rand} - ®•♡❥❦❧☙"} }
+
+      specify 'only updates the description' do
+        expect(update).to be true
+        expect(video.description).not_to eq old_description
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the tags' do
+      let!(:old_tags) { video.tags }
+      let(:attrs) { {tags: ["Yt Test Tag #{rand}"]} }
+
+      specify 'only updates the tag' do
+        expect(update).to be true
+        expect(video.tags).not_to eq old_tags
+        expect(video.title).to eq old_title
+        expect(video.privacy_status).to eq old_privacy_status
+      end
+    end
+
+    context 'given I update the category ID' do
+      let!(:old_category_id) { video.category_id }
+      let!(:new_category_id) { old_category_id == '22' ? '21' : '22' }
+
+      context 'passing the parameter in underscore syntax' do
+        let(:attrs) { {category_id: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+          expect(video.title).to eq old_title
+          expect(video.privacy_status).to eq old_privacy_status
+        end
+      end
+
+      context 'passing the parameter in camel-case syntax' do
+        let(:attrs) { {categoryId: new_category_id} }
+
+        specify 'only updates the category ID' do
+          expect(update).to be true
+          expect(video.category_id).not_to eq old_category_id
+        end
+      end
     end
 
     it 'returns valid reports for video-related metrics' do

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -100,7 +100,7 @@ describe Yt::Video, :device_app do
   end
 
   context 'given one of my own videos that I want to update' do
-    let(:id) { $account.videos.first.id }
+    let(:id) { $account.videos.where(order: 'viewCount').first.id }
     let!(:old_title) { video.title }
     let!(:old_privacy_status) { video.privacy_status }
     let(:update) { video.update attrs }


### PR DESCRIPTION
This commit also extracts the commonality between the `update`
methods of Video and Playlist into a `Resource#update` method.
