### PR TITLE
Added LiveStream attributes to video

### DIFF
--- a/lib/yt/collections/live_streaming_details.rb
+++ b/lib/yt/collections/live_streaming_details.rb
@@ -1,0 +1,31 @@
+require 'yt/collections/base'
+require 'yt/models/live_streaming_detail'
+
+module Yt
+  module Collections
+    class LiveStreamingDetails < Base
+
+    private
+
+      # @return [Yt::Models::ContentDetail] a new content detail initialized
+      #   with one of the items returned by asking YouTube for a list of them.
+      def new_item(data)
+        Yt::LiveStreamingDetail.new data: data['liveStreamingDetails']
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to get the
+      #   content detail of a resource, for instance a video.
+      # @see https://developers.google.com/youtube/v3/docs/videos#resource
+      def list_params
+        super.tap do |params|
+          params[:params] = live_streaming_details_params
+          params[:path] = '/youtube/v3/videos'
+        end
+      end
+
+      def live_streaming_details_params
+        {max_results: 50, part: 'liveStreamingDetails', id: @parent.id}
+      end
+    end
+  end
+end

--- a/lib/yt/models/live_streaming_detail.rb
+++ b/lib/yt/models/live_streaming_detail.rb
@@ -1,0 +1,40 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # Encapsulates information about the live content
+    # @see https://developers.google.com/youtube/v3/docs/videos#resource
+    class LiveStreamingDetail < Base
+
+      def initialize(options = {})
+        @data = options[:data]
+      end
+
+      # @return [Time] The time that the broadcast actually started
+      def actual_start_time
+        @actual_start_time ||= Time.parse @data['actualStartTime']
+      end
+
+      # @return [Time] The time that the broadcast actually ended
+      def actual_end_time
+        @actual_end_time ||= Time.parse @data['actualEndTime']
+      end
+
+      # @return [Time] The time that the broadcast is scheduled to begin
+      def scheduled_start_time
+        @scheduled_start_time ||= Time.parse @data['scheduledStartTime']
+      end
+
+      # @return [Time] The time that the broadcast is scheduled to end
+      def scheduled_end_time
+        @scheduled_end_time ||= Time.parse @data['scheduledEndTime']
+      end
+
+      # @return [integer] The number of viewers currently watching the broadcast.
+      def concurrent_viewers
+        @concurrent_viewers ||= @data['concurrentViewers'].to_i
+      end
+
+    end
+  end
+end

--- a/lib/yt/models/live_streaming_detail.rb
+++ b/lib/yt/models/live_streaming_detail.rb
@@ -12,22 +12,23 @@ module Yt
 
       # @return [Time] The time that the broadcast actually started
       def actual_start_time
-        @actual_start_time ||= Time.parse @data['actualStartTime'] if @data['actualStartTime']
+        @actual_start_time ||= Time.zone.parse @data['actualStartTime'] if @data['actualStartTime']
       end
 
       # @return [Time] The time that the broadcast actually ended
       def actual_end_time
-        @actual_end_time ||= Time.parse @data['actualEndTime'] if @data['actualEndTime']
+        @actual_end_time ||= Time.zone.parse @data['actualEndTime'] if @data['actualEndTime']
       end
 
       # @return [Time] The time that the broadcast is scheduled to begin
       def scheduled_start_time
-        @scheduled_start_time ||= Time.parse @data['scheduledStartTime'] if @data['scheduledStartTime']
+        print @data['scheduledStartTime']
+        @scheduled_start_time ||= Time.zone.parse @data['scheduledStartTime'] if @data['scheduledStartTime']
       end
 
       # @return [Time] The time that the broadcast is scheduled to end
       def scheduled_end_time
-        @scheduled_end_time ||= Time.parse @data['scheduledEndTime'] if @data['scheduledEndTime']
+        @scheduled_end_time ||= Time.zone.parse @data['scheduledEndTime'] if @data['scheduledEndTime']
       end
 
       # @return [integer] The number of viewers currently watching the broadcast.

--- a/lib/yt/models/live_streaming_detail.rb
+++ b/lib/yt/models/live_streaming_detail.rb
@@ -12,22 +12,22 @@ module Yt
 
       # @return [Time] The time that the broadcast actually started
       def actual_start_time
-        @actual_start_time ||= Time.parse @data['actualStartTime']
+        @actual_start_time ||= Time.parse @data['actualStartTime'] if @data['actualStartTime']
       end
 
       # @return [Time] The time that the broadcast actually ended
       def actual_end_time
-        @actual_end_time ||= Time.parse @data['actualEndTime']
+        @actual_end_time ||= Time.parse @data['actualEndTime'] if @data['actualEndTime']
       end
 
       # @return [Time] The time that the broadcast is scheduled to begin
       def scheduled_start_time
-        @scheduled_start_time ||= Time.parse @data['scheduledStartTime']
+        @scheduled_start_time ||= Time.parse @data['scheduledStartTime'] if @data['scheduledStartTime']
       end
 
       # @return [Time] The time that the broadcast is scheduled to end
       def scheduled_end_time
-        @scheduled_end_time ||= Time.parse @data['scheduledEndTime']
+        @scheduled_end_time ||= Time.parse @data['scheduledEndTime'] if @data['scheduledEndTime']
       end
 
       # @return [integer] The number of viewers currently watching the broadcast.

--- a/lib/yt/models/snippet.rb
+++ b/lib/yt/models/snippet.rb
@@ -49,7 +49,7 @@ module Yt
       # @return [Time] if the resource is a video, the date and time that the
       #   video was published.
       def published_at
-        @published_at ||= Time.parse @data['publishedAt']
+        @published_at ||= Time.zone.parse @data['publishedAt']
       end
 
       # @param [Symbol, String] size The size of the thumbnail to retrieve.

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -27,6 +27,11 @@ module Yt
       #   @return [Yt::Models::Rating] the video’s rating.
       has_one :rating
 
+      # @!attribute [r] live_streaming_details
+      #   @return [Yt::Models::LiveStreamingDetail] live streaming details.
+      has_one :live_streaming_detail
+      delegate :actual_start_time, :actual_end_time, :scheduled_start_time, :scheduled_end_time, :concurrent_viewers, to: :live_streaming_detail
+
       # @!attribute [r] annotations
       #   @return [Yt::Collections::Annotations] the video’s annotations.
       has_many :annotations


### PR DESCRIPTION
I wanted to list live videos with scheduled date in the future. It was unfortunately impossible since these attributes are in "liveStreamingDetails". I copied what you did for contentDetail to respect your pattern.
