### PR TITLE
Added LiveStreamDetail attributes to video

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.9.3)
+    yt (0.9.4)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,7 +6,7 @@ v0.9 - 2014/07/28
 * Add content_owner.policies to list ContentID policies
 * Let 'update' methods understand both under_score and camelCased parameters
 * Add claim.third_party?
-
+* Add actual_start_time, actual_end_time, scheduled_start_time, scheduled_end_time for live-streaming videos
 
 v0.8 - 2014/07/18
 -----------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.9.3'
+    gem 'yt', '~> 0.9.4'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)
@@ -210,6 +210,7 @@ Use [Yt::Video](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models/Video)
 * like and dislike a video
 * retrieve the daily earnings, views, comments, likes, dislikes, shares and impressions of a video
 * retrieve the viewer percentage of a video by gender and age group
+* retrieve data about live-streaming videos
 
 ```ruby
 # Videos can be initialized with ID or URL
@@ -259,6 +260,12 @@ video.hd? #=> true
 video.stereoscopic? #=> false
 video.captioned? #=> true
 video.licensed? #=> false
+
+video.actual_start_time #=> Tue, 27 May 2014 12:50:00
+video.actual_end_time #=> Tue, 27 May 2014 12:54:00
+video.scheduled_start_time #=> Tue, 27 May 2014 12:49:00
+video.scheduled_end_time #=> Tue, 27 May 2014 12:55:00
+video.concurrent_viewers #=> 0
 
 video.annotations.count #=> 1
 video.annotations.first #=> #<Yt::Models::Annotation @id=...>

--- a/lib/yt/collections/live_streaming_details.rb
+++ b/lib/yt/collections/live_streaming_details.rb
@@ -1,0 +1,32 @@
+require 'yt/collections/base'
+require 'yt/models/live_streaming_detail'
+
+module Yt
+  module Collections
+    class LiveStreamingDetails < Base
+
+    private
+
+      # @return [Yt::Models::LiveStreamingDetail] a new live streaming detail
+      #   initialized with one of the items returned by asking YouTube for a
+      #   list of them.
+      def new_item(data)
+        Yt::LiveStreamingDetail.new data: data['liveStreamingDetails']
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to get the
+      #   live streaming detail of a resource, for instance a video.
+      # @see https://developers.google.com/youtube/v3/docs/videos#resource
+      def list_params
+        super.tap do |params|
+          params[:params] = live_streaming_details_params
+          params[:path] = '/youtube/v3/videos'
+        end
+      end
+
+      def live_streaming_details_params
+        {max_results: 50, part: 'liveStreamingDetails', id: @parent.id}
+      end
+    end
+  end
+end

--- a/lib/yt/models/live_streaming_detail.rb
+++ b/lib/yt/models/live_streaming_detail.rb
@@ -1,0 +1,61 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # Encapsulates information about a live video broadcast.
+    # The object will only be present in a video resource if the video is an
+    # upcoming, live, or completed live broadcast.
+    # @see https://developers.google.com/youtube/v3/docs/videos#resource
+    class LiveStreamingDetail < Base
+
+      def initialize(options = {})
+        @data = options[:data] || {}
+      end
+
+      # @return [Time] if the broadcast has begun, the time that the broadcast
+      #   actually started.
+      # @return [nil] if the broadcast has not begun.
+      def actual_start_time
+        @actual_start_time ||= if @data['actualStartTime']
+          Time.parse @data['actualStartTime']
+        end
+      end
+
+      # @return [Time] if the broadcast is over, the time that the broadcast
+      #   actually ended.
+      # @return [nil] if the broadcast is not over.
+      def actual_end_time
+        @actual_end_time ||= if @data['actualEndTime']
+          Time.parse @data['actualEndTime']
+        end
+      end
+
+      # @return [Time] the time that the broadcast is scheduled to begin.
+      def scheduled_start_time
+        @scheduled_start_time ||= if @data['scheduledStartTime']
+          Time.parse @data['scheduledStartTime']
+        end
+      end
+
+      # @return [Time] if the broadcast is scheduled to end, the time that the
+      #   broadcast is scheduled to end.
+      # @return [nil] if the broadcast is scheduled to continue indefinitely.
+      def scheduled_end_time
+        @scheduled_end_time ||= if @data['scheduledEndTime']
+          Time.parse @data['scheduledEndTime']
+        end
+      end
+
+      # @return [Integer] if the broadcast has current viewers and the
+      #   broadcast owner has not hidden the viewcount for the video, the
+      #   number of viewers currently watching the broadcast.
+      # @return [nil] if the broadcast has ended or the broadcast owner has
+      #   hidden the viewcount for the video.
+      def concurrent_viewers
+        @concurrent_viewers ||= if @data['concurrentViewers']
+          @data['concurrentViewers'].to_i
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -27,6 +27,12 @@ module Yt
       #   @return [Yt::Models::Rating] the video’s rating.
       has_one :rating
 
+      # @!attribute [r] live_streaming_detail
+      #   @return [Yt::Models::LiveStreamingDetail] live streaming detail.
+      has_one :live_streaming_detail
+      delegate :actual_start_time, :actual_end_time, :scheduled_start_time,
+        :scheduled_end_time, :concurrent_viewers, to: :live_streaming_detail
+
       # @!attribute [r] annotations
       #   @return [Yt::Collections::Annotations] the video’s annotations.
       has_many :annotations

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.9.3'
+  VERSION = '0.9.4'
 end

--- a/spec/models/live_streaming_detail_spec.rb
+++ b/spec/models/live_streaming_detail_spec.rb
@@ -1,0 +1,86 @@
+require 'spec_helper'
+require 'yt/models/live_streaming_detail'
+
+describe Yt::LiveStreamingDetail do
+  subject(:live_streaming_detail) { Yt::LiveStreamingDetail.new data: data }
+
+  describe '#actual_start_time' do
+    context 'given a non-live streaming video' do
+      let(:data) { {} }
+      it { expect(live_streaming_detail.actual_start_time).to be_nil }
+    end
+
+    context 'given a live streaming video that has not started yet' do
+      let(:data) { {"scheduledStartTime"=>"2017-07-10T00:00:00.000Z"} }
+      it { expect(live_streaming_detail.actual_start_time).to be_nil }
+    end
+
+    context 'given a live streaming video that has started' do
+      let(:data) { {"actualStartTime"=>"2014-08-01T17:48:40.678Z"} }
+      it { expect(live_streaming_detail.actual_start_time.year).to be 2014 }
+    end
+  end
+
+  describe '#actual_end_time' do
+    context 'given a non-live streaming video' do
+      let(:data) { {} }
+      it { expect(live_streaming_detail.actual_end_time).to be_nil }
+    end
+
+    context 'given a live streaming video that has not ended yet' do
+      let(:data) { {"scheduledStartTime"=>"2017-07-10T00:00:00.000Z"} }
+      it { expect(live_streaming_detail.actual_end_time).to be_nil }
+    end
+
+    context 'given a live streaming video that has ended' do
+      let(:data) { {"actualEndTime"=>"2014-08-01T17:48:40.678Z"} }
+      it { expect(live_streaming_detail.actual_end_time.year).to be 2014 }
+    end
+  end
+
+  describe '#scheduled_start_time' do
+    context 'given a non-live streaming video' do
+      let(:data) { {} }
+      it { expect(live_streaming_detail.scheduled_start_time).to be_nil }
+    end
+
+    context 'given a live streaming video' do
+      let(:data) { {"scheduledStartTime"=>"2017-07-10T00:00:00.000Z"} }
+      it { expect(live_streaming_detail.scheduled_start_time.year).to be 2017 }
+    end
+  end
+
+  describe '#scheduled_end_time' do
+    context 'given a non-live streaming video' do
+      let(:data) { {} }
+      it { expect(live_streaming_detail.scheduled_end_time).to be_nil }
+    end
+
+    context 'given a live streaming video that broadcasts indefinitely' do
+      let(:data) { {"scheduledStartTime"=>"2017-07-10T00:00:00.000Z"} }
+      it { expect(live_streaming_detail.scheduled_end_time).to be_nil }
+    end
+
+    context 'given a live streaming video with a scheduled ednd' do
+      let(:data) { {"scheduledEndTime"=>"2014-08-01T17:48:40.678Z"} }
+      it { expect(live_streaming_detail.scheduled_end_time.year).to be 2014 }
+    end
+  end
+
+  describe '#concurrent_viewers' do
+    context 'given a non-live streaming video' do
+      let(:data) { {} }
+      it { expect(live_streaming_detail.concurrent_viewers).to be_nil }
+    end
+
+    context 'given a current live streaming video with viewers' do
+      let(:data) { {"concurrentViewers"=>"1"} }
+      it { expect(live_streaming_detail.concurrent_viewers).to be 1 }
+    end
+
+    context 'given a past live streaming video' do
+      let(:data) { {"actualEndTime"=>"2013-08-01T17:48:40.678Z"} }
+      it { expect(live_streaming_detail.concurrent_viewers).to be_nil }
+    end
+  end
+end

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -58,6 +58,11 @@ describe Yt::Video, :device_app do
       expect(video.licensed_as_standard_youtube?).to be_in [true, false]
       expect(video.has_public_stats_viewable?).to be_in [true, false]
       expect(video.embeddable?).to be_in [true, false]
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_nil
+      expect(video.scheduled_end_time).to be_nil
+      expect(video.concurrent_viewers).to be_nil
     end
 
     it { expect{video.update}.to fail }
@@ -79,6 +84,29 @@ describe Yt::Video, :device_app do
       before { video.unlike }
       it { expect(video).not_to be_liked }
       it { expect(video.like).to be true }
+    end
+  end
+
+  context 'given someone else’s live video broadcast scheduled in the future' do
+    let(:id) { 'PqzGI8gO_gk' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_nil
+      expect(video.actual_end_time).to be_nil
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_nil
+    end
+  end
+
+  context 'given someone else’s past live video broadcast' do
+    let(:id) { 'COOM8_tOy6U' }
+
+    it 'returns valid live streaming details' do
+      expect(video.actual_start_time).to be_a Time
+      expect(video.actual_end_time).to be_a Time
+      expect(video.scheduled_start_time).to be_a Time
+      expect(video.scheduled_end_time).to be_a Time
+      expect(video.concurrent_viewers).to be_nil
     end
   end
 


### PR DESCRIPTION
Note: I made this PR adding documentation and specs to Grafikart’s code from #50 so I can remember about it once YouTube API goes back to functioning normally and tests stop failing because of YouTube API.

I won’t merge into master (and bump version) while tests fail… so until YouTube is back to normal, but the code looks good.
