### PR TITLE
Allow angle brackets when editing videos/playlists

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.9.3)
+    yt (0.9.4)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,7 @@ v0.9 - 2014/07/28
 * Add content_owner.policies to list ContentID policies
 * Let 'update' methods understand both under_score and camelCased parameters
 * Add claim.third_party?
+* Allow angle brackets when editing title, description, tags and replace them with similar characters allowed by YouTube
 
 
 v0.8 - 2014/07/18

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.9.3'
+    gem 'yt', '~> 0.9.4'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)
@@ -280,7 +280,7 @@ video.like #=> true
 account = Yt::Account.new access_token: 'ya29.1.ABCDEFGHIJ'
 video = Yt::Video.new id: 'MESycYJytkU', auth: account
 
-video.update title: 'A title', description: 'A description', tags: ['a tag'], categoryId: '21'
+video.update title: 'A title', description: 'A description <with angle brackets>', tags: ['a tag'], categoryId: '21'
 
 video.views since: 7.days.ago #=> {Wed, 28 May 2014 => 12.0, Thu, 29 May 2014 => 3.0, …}
 video.comments until: 2.days.ago #=> {Wed, 28 May 2014 => 9.0, Thu, 29 May 2014 => 4.0, …}
@@ -346,7 +346,7 @@ playlist.playlist_items.first #=> #<Yt::Models::PlaylistItem @id=...>
 *The methods above do not require authentication.*
 
 ```ruby
-playlist.update title: 'title', description: 'desc', tags: ['new tag'], privacy_status: 'private'
+playlist.update title: 'A <title> with angle brackets', description: 'desc', tags: ['new tag'], privacy_status: 'private'
 playlist.add_video 'MESycYJytkU'
 playlist.add_videos ['MESycYJytkU', 'MESycYJytkU']
 playlist.delete_playlist_items title: 'Fullscreen Creator Platform' #=> [true]

--- a/lib/yt/models/playlist.rb
+++ b/lib/yt/models/playlist.rb
@@ -68,7 +68,8 @@ module Yt
 
       # @see https://developers.google.com/youtube/v3/docs/playlists/update
       def update_parts
-        snippet = {keys: [:title, :description, :tags], required: true}
+        keys = [:title, :description, :tags]
+        snippet = {keys: keys, required: true, sanitize_brackets: true}
         status = {keys: [:privacy_status]}
         {snippet: snippet, status: status}
       end

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -158,7 +158,7 @@ module Yt
       # @todo: Add status, recording details keys
       def update_parts
         snippet_keys = [:title, :description, :tags, :category_id]
-        {snippet: {keys: snippet_keys}}
+        {snippet: {keys: snippet_keys, sanitize_brackets: true}}
       end
     end
   end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.9.3'
+  VERSION = '0.9.4'
 end

--- a/spec/requests/as_account/playlist_spec.rb
+++ b/spec/requests/as_account/playlist_spec.rb
@@ -91,6 +91,17 @@ describe Yt::Playlist, :device_app do
       end
     end
 
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(playlist.title).to eq 'Yt Test ‹ ›'
+        expect(playlist.description).to eq '‹ ›'
+        expect(playlist.tags).to eq ['‹tag›']
+      end
+    end
+
     context 'given I update the privacy status' do
       let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
 

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -166,6 +166,17 @@ describe Yt::Video, :device_app do
       end
     end
 
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(video.title).to eq 'Yt Test ‹ ›'
+        expect(video.description).to eq '‹ ›'
+        expect(video.tags).to eq ['‹tag›']
+      end
+    end
+
     it 'returns valid reports for video-related metrics' do
       # Some reports are only available to Content Owners.
       # See content ownere test for more details about what the methods return.


### PR DESCRIPTION
Angle brackets are not characters allowed by YouTube, but instead
of failing, Yt replaces them with Unicode characters that look very
similar and are accepted by YouTube.
