### PR TITLE
Update video status

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.9.4)
+    yt (0.9.5)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,6 +7,7 @@ v0.9 - 2014/07/28
 * Let 'update' methods understand both under_score and camelCased parameters
 * Add claim.third_party?
 * Add actual_start_time, actual_end_time, scheduled_start_time, scheduled_end_time for live-streaming videos
+* Add privacy_status, public_stats_viewable, publish_at to the options that Video#update accepts
 
 v0.8 - 2014/07/18
 -----------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.9.4'
+    gem 'yt', '~> 0.9.5'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/models/status.rb
+++ b/lib/yt/models/status.rb
@@ -1,3 +1,5 @@
+require 'yt/models/timestamp'
+
 module Yt
   module Models
     # Contains information about the status of a resource. The details of the
@@ -247,8 +249,9 @@ module Yt
       # @return [nil] if the resource is not a private video scheduled to be
       #   published.
       def scheduled_at
-        @scheduled_at ||= Time.parse @data['publishAt'] if scheduled?
+        @scheduled_at ||= Yt::Timestamp.parse @data['publishAt'] if scheduled?
       end
+      alias publish_at scheduled_at
 
       # Returns whether the video is scheduled to be published.
       # @return [Boolean] if the resource is a video, whether it is currently
@@ -295,6 +298,7 @@ module Yt
       def embeddable?
         @embeddable ||= @data['embeddable']
       end
+      alias embeddable embeddable?
 
 # Public stats (Video only)
 
@@ -308,6 +312,7 @@ module Yt
       def has_public_stats_viewable?
         @public_stats_viewable ||= @data['publicStatsViewable']
       end
+      alias public_stats_viewable has_public_stats_viewable?
 
     private
 

--- a/lib/yt/models/timestamp.rb
+++ b/lib/yt/models/timestamp.rb
@@ -1,0 +1,12 @@
+module Yt
+  module Models
+    # Extend Time to have .to_json return the format needed to submit
+    # timestamp to YouTube API.
+    # Only needed while we support ActiveSupport 3.
+    class Timestamp < Time
+      def as_json(options = nil)
+        utc.iso8601(3)
+      end
+    end
+  end
+end

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -11,11 +11,11 @@ module Yt
       delegate :deleted?, :failed?, :processed?, :rejected?, :uploaded?,
         :uses_unsupported_codec?, :has_failed_conversion?, :empty?, :invalid?,
         :too_small?, :aborted?, :claimed?, :infringes_copyright?, :duplicate?,
-        :scheduled_at, :scheduled?, :too_long?, :violates_terms_of_use?,
+        :scheduled_at, :publish_at, :scheduled?, :too_long?, :violates_terms_of_use?,
         :inappropriate?, :infringes_trademark?, :belongs_to_closed_account?,
         :belongs_to_suspended_account?, :licensed_as_creative_commons?,
         :licensed_as_standard_youtube?, :has_public_stats_viewable?,
-        :embeddable?, to: :status
+        :public_stats_viewable, :embeddable, :embeddable?, :license, to: :status
 
       # @!attribute [r] content_detail
       #   @return [Yt::Models::ContentDetail] the video’s content details.
@@ -83,14 +83,11 @@ module Yt
         !@id.nil?
       end
 
-      # @todo Update the status, not just the snippet. This requires some
-      #   caution, as the whole status object needs to be updated, not just
-      #   privacyStatus, but also embeddable, license, publicStatsViewable,
-      #   and publishAt
       def update(attributes = {})
         super attributes do |data|
           @id = data['id']
           @snippet = Snippet.new data: data['snippet'] if data['snippet']
+          @status = Status.new data: data['status'] if data['status']
           true
         end
       end
@@ -161,10 +158,12 @@ module Yt
     private
 
       # @see https://developers.google.com/youtube/v3/docs/videos/update
-      # @todo: Add status, recording details keys
+      # @todo: Add recording details keys
       def update_parts
         snippet_keys = [:title, :description, :tags, :category_id]
-        {snippet: {keys: snippet_keys}}
+        status_keys = [:privacy_status, :embeddable, :license,
+          :public_stats_viewable, :publish_at]
+        {snippet: {keys: snippet_keys}, status: {keys: status_keys}}
       end
     end
   end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.9.4'
+  VERSION = '0.9.5'
 end


### PR DESCRIPTION
Previously Video#update could only update snippet parameters such
as title, description. After this commit, status parameters can be
updated as well.

Unfortunately, YouTube does not let users update most of the status
parameters through the API: only privacyStatus, publicStatsViewable
and publishAt can indeed be updated.

Furthermore, updating `publishAt` sometimes raises a YouTube error
if the video is private but used to be unlisted.
