### PR TITLE
Sanitize angle brackets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.9.5)
+    yt (0.9.6)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,7 @@ v0.9 - 2014/07/28
 * Add claim.third_party?
 * Add actual_start_time, actual_end_time, scheduled_start_time, scheduled_end_time for live-streaming videos
 * Add privacy_status, public_stats_viewable, publish_at to the options that Video#update accepts
+* Allow angle brackets when editing title, description, tags and replace them with similar characters allowed by YouTube
 
 v0.8 - 2014/07/18
 -----------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.9.5'
+    gem 'yt', '~> 0.9.6'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ video.like #=> true
 account = Yt::Account.new access_token: 'ya29.1.ABCDEFGHIJ'
 video = Yt::Video.new id: 'MESycYJytkU', auth: account
 
-video.update title: 'A title', description: 'A description', tags: ['a tag'], categoryId: '21'
+video.update title: 'A title', description: 'A description <with angle brackets>', tags: ['a tag'], categoryId: '21'
 
 video.views since: 7.days.ago #=> {Wed, 28 May 2014 => 12.0, Thu, 29 May 2014 => 3.0, …}
 video.comments until: 2.days.ago #=> {Wed, 28 May 2014 => 9.0, Thu, 29 May 2014 => 4.0, …}
@@ -353,7 +353,7 @@ playlist.playlist_items.first #=> #<Yt::Models::PlaylistItem @id=...>
 *The methods above do not require authentication.*
 
 ```ruby
-playlist.update title: 'title', description: 'desc', tags: ['new tag'], privacy_status: 'private'
+playlist.update title: 'A <title> with angle brackets', description: 'desc', tags: ['new tag'], privacy_status: 'private'
 playlist.add_video 'MESycYJytkU'
 playlist.add_videos ['MESycYJytkU', 'MESycYJytkU']
 playlist.delete_playlist_items title: 'Fullscreen Creator Platform' #=> [true]

--- a/lib/yt/actions/delete_all.rb
+++ b/lib/yt/actions/delete_all.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'yt/actions/list'
 require 'yt/models/request'
 
@@ -20,7 +21,8 @@ module Yt
             # TODO: could be symbol etc...
             item.respond_to?(method) && case value
             when Regexp then item.send(method) =~ value
-            else item.send(method) == value
+            when Array then item.send(method) == value.map{|item| item.to_s.gsub('<', '‹').gsub('>', '›')}
+            else item.send(method) == value.to_s.gsub('<', '‹').gsub('>', '›')
             end
           end
         end

--- a/lib/yt/collections/playlist_items.rb
+++ b/lib/yt/collections/playlist_items.rb
@@ -4,12 +4,8 @@ module Yt
   module Collections
     class PlaylistItems < Resources
 
-      # attrs are id and kind
-      def insert(attrs = {}, options = {}) #
-        resource = {kind: "youtube##{attrs[:kind]}"}
-        resource["#{attrs[:kind]}Id"] = attrs[:id]
-        snippet = {playlistId: @parent.id, resourceId: resource}
-        do_insert body: {snippet: snippet}, params: {part: 'snippet,status'}
+      def insert(attributes = {}, options = {})
+        super attributes.merge(playlist_id: @parent.id), options
       rescue Yt::Error => error
         ignorable_errors = error.reasons & ['videoNotFound', 'forbidden']
         raise error unless options[:ignore_errors] && ignorable_errors.any?
@@ -17,14 +13,18 @@ module Yt
 
     private
 
-      # @return [Hash] the parameters to submit to YouTube to list channels.
-      # @see https://developers.google.com/youtube/v3/docs/channels/list
+      # @return [Hash] the parameters to submit to YouTube to list playlist items.
+      # @see https://developers.google.com/youtube/v3/docs/playlistItems/list
       def list_params
         super.tap{|params| params[:params] = playlist_items_params}
       end
 
       def playlist_items_params
         resources_params.merge playlist_id: @parent.id
+      end
+
+      def insert_parts
+        {snippet: {keys: [:playlist_id, :resource_id]}}
       end
     end
   end

--- a/lib/yt/collections/playlists.rb
+++ b/lib/yt/collections/playlists.rb
@@ -4,20 +4,6 @@ module Yt
   module Collections
     class Playlists < Resources
 
-      # Valid body (no defaults) are: title (string), description (string), privacy_status (string),
-      # tags (array of strings)
-      def insert(options = {})
-        body = {}
-
-        snippet = options.slice :title, :description, :tags
-        body[:snippet] = snippet if snippet.any?
-
-        status = options[:privacy_status]
-        body[:status] = {privacyStatus: status} if status
-
-        do_insert body: body, params: {part: 'snippet,status'}
-      end
-
     private
 
       # @return [Hash] the parameters to submit to YouTube to list channels.
@@ -28,6 +14,12 @@ module Yt
 
       def playlists_params
         resources_params.merge channel_id: @parent.id
+      end
+
+      def insert_parts
+        snippet = {keys: [:title, :description, :tags], sanitize_brackets: true}
+        status = {keys: [:privacy_status]}
+        {snippet: snippet, status: status}
       end
     end
   end

--- a/lib/yt/models/playlist.rb
+++ b/lib/yt/models/playlist.rb
@@ -74,8 +74,10 @@ module Yt
         {snippet: snippet, status: status}
       end
 
+      # @todo: extend camelize to also camelize the nested hashes, so we
+      #   don’t have to write videoId
       def video_params(video_id)
-        {id: video_id, kind: :video}
+        {resource_id: {kind: 'youtube#video', videoId: video_id}}
       end
     end
   end

--- a/lib/yt/models/playlist.rb
+++ b/lib/yt/models/playlist.rb
@@ -68,7 +68,8 @@ module Yt
 
       # @see https://developers.google.com/youtube/v3/docs/playlists/update
       def update_parts
-        snippet = {keys: [:title, :description, :tags], required: true}
+        keys = [:title, :description, :tags]
+        snippet = {keys: keys, required: true, sanitize_brackets: true}
         status = {keys: [:privacy_status]}
         {snippet: snippet, status: status}
       end

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -161,9 +161,10 @@ module Yt
       # @todo: Add recording details keys
       def update_parts
         snippet_keys = [:title, :description, :tags, :category_id]
+        snippet = {keys: snippet_keys, sanitize_brackets: true}
         status_keys = [:privacy_status, :embeddable, :license,
           :public_stats_viewable, :publish_at]
-        {snippet: {keys: snippet_keys}, status: {keys: status_keys}}
+        {snippet: snippet, status: {keys: status_keys}}
       end
     end
   end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.9.5'
+  VERSION = '0.9.6'
 end

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -54,9 +54,9 @@ describe Yt::Channel, :device_app do
 
   context 'given my own channel' do
     let(:id) { $account.channel.id }
-    let(:title) { 'Yt Test title' }
-    let(:description) { 'Yt Test description' }
-    let(:tags) { ['Yt Test Tag 1', 'Yt Test Tag 2'] }
+    let(:title) { 'Yt Test <title>' }
+    let(:description) { 'Yt Test <description>' }
+    let(:tags) { ['Yt Test Tag 1', 'Yt Test <Tag> 2'] }
     let(:privacy_status) { 'unlisted' }
     let(:params) { {title: title, description: description, tags: tags, privacy_status: privacy_status} }
 

--- a/spec/requests/as_account/playlist_spec.rb
+++ b/spec/requests/as_account/playlist_spec.rb
@@ -91,6 +91,17 @@ describe Yt::Playlist, :device_app do
       end
     end
 
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(playlist.title).to eq 'Yt Test ‹ ›'
+        expect(playlist.description).to eq '‹ ›'
+        expect(playlist.tags).to eq ['‹tag›']
+      end
+    end
+
     context 'given I update the privacy status' do
       let!(:new_privacy_status) { old_privacy_status == 'private' ? 'unlisted' : 'private' }
 

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -195,11 +195,11 @@ describe Yt::Video, :device_app do
     end
 
     context 'given I update title, description and/or tags using angle brackets' do
-      let(:attrs) { {title: "Yt Test < >", description: '< >', tags: ['<tag>']} }
+      let(:attrs) { {title: "Example Yt Test < >", description: '< >', tags: ['<tag>']} }
 
       specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
         expect(update).to be true
-        expect(video.title).to eq 'Yt Test ‹ ›'
+        expect(video.title).to eq 'Example Yt Test ‹ ›'
         expect(video.description).to eq '‹ ›'
         expect(video.tags).to eq ['‹tag›']
       end

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -194,6 +194,17 @@ describe Yt::Video, :device_app do
       end
     end
 
+    context 'given I update title, description and/or tags using angle brackets' do
+      let(:attrs) { {title: "Yt Test < >", description: '< >', tags: ['<tag>']} }
+
+      specify 'updates them replacing angle brackets with similar unicode characters accepted by YouTube' do
+        expect(update).to be true
+        expect(video.title).to eq 'Yt Test ‹ ›'
+        expect(video.description).to eq '‹ ›'
+        expect(video.tags).to eq ['‹tag›']
+      end
+    end
+
     # note: 'scheduled' videos cannot be set to 'unlisted'
     context 'given I update the privacy status' do
       before { video.update publish_at: nil if video.scheduled? }
@@ -347,5 +358,4 @@ describe Yt::Video, :device_app do
       end
     end
   end
-
 end


### PR DESCRIPTION
Angle brackets are not characters allowed by YouTube, but instead
of failing, Yt replaces them with Unicode characters that look very
similar and are accepted by YouTube.
