### PR TITLE
Also parse weeks and days in video’s duration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.9.6)
+    yt (0.9.7)
       activesupport
 
 GEM

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -9,6 +9,7 @@ v0.9 - 2014/07/28
 * Add actual_start_time, actual_end_time, scheduled_start_time, scheduled_end_time for live-streaming videos
 * Add privacy_status, public_stats_viewable, publish_at to the options that Video#update accepts
 * Allow angle brackets when editing title, description, tags and replace them with similar characters allowed by YouTube
+* Correctly parse duration of videos longer than 24 hours
 
 v0.8 - 2014/07/18
 -----------------

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.9.6'
+    gem 'yt', '~> 0.9.7'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/models/content_detail.rb
+++ b/lib/yt/models/content_detail.rb
@@ -39,19 +39,35 @@ module Yt
 
     private
 
-      # The duration of the resource as reported by YouTube. The value is an
-      # ISO 8601 duration in the format PT#M#S, in which the letters PT
-      # indicate that the value specifies a period of time, and the letters M
-      # and S refer to length in minutes and seconds, respectively. The #
-      # characters preceding the M and S letters are both integers that specify
-      # the number of minutes (or seconds) of the video. For example, a value
-      # of PT15M51S indicates that the video is 15 minutes and 51 seconds long.
+      # @return [Integer] the duration of the resource as reported by YouTube.
+      # @see https://developers.google.com/youtube/v3/docs/videos
+      #
+      # According to YouTube documentation, the value is an ISO 8601 duration
+      # in the format PT#M#S, in which the letters PT indicate that the value
+      # specifies a period of time, and the letters M and S refer to length in
+      # minutes and seconds, respectively. The # characters preceding the M and
+      # S letters are both integers that specify the number of minutes (or
+      # seconds) of the video. For example, a value of PT15M51S indicates that
+      # the video is 15 minutes and 51 seconds long.
+      #
+      # The ISO 8601 duration standard, though, is not +always+ respected by
+      # the results returned by YouTube API. For instance: video 2XwmldWC_Ls
+      # reports a duration of 'P1W2DT6H21M32S', which is to be interpreted as
+      # 1 week, 2 days, 6 hours, 21 minutes, 32 seconds. Mixing weeks with
+      # other time units is not strictly part of ISO 8601; in this context,
+      # weeks will be interpreted as "the duration of 7 days". Similarly, a
+      # day will be interpreted as "the duration of 24 hours".
+      # Video tPEE9ZwTmy0 reports a duration of 'PT2S'. Skipping time units
+      # such as minutes is not part of the standard either; in this context,
+      # it will be interpreted as "0 minutes and 2 seconds".
       def to_seconds(iso8601_duration)
-        match = iso8601_duration.match %r{^PT(?:|(?<hours>\d*?)H)(?:|(?<min>\d*?)M)(?:|(?<sec>\d*?)S)$}
+        match = iso8601_duration.match %r{^P(?:|(?<weeks>\d*?)W)(?:|(?<days>\d*?)D)(?:|T(?:|(?<hours>\d*?)H)(?:|(?<min>\d*?)M)(?:|(?<sec>\d*?)S))$}
+        weeks = (match[:weeks] || '0').to_i
+        days = (match[:days] || '0').to_i
         hours = (match[:hours] || '0').to_i
         minutes = (match[:min] || '0').to_i
         seconds = (match[:sec]).to_i
-        (hours * 60 + minutes) * 60 + seconds
+        (((((weeks * 7) + days) * 24 + hours) * 60) + minutes) * 60 + seconds
       end
     end
   end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.9.6'
+  VERSION = '0.9.7'
 end

--- a/spec/models/content_detail_spec.rb
+++ b/spec/models/content_detail_spec.rb
@@ -5,6 +5,16 @@ describe Yt::ContentDetail do
   subject(:content_detail) { Yt::ContentDetail.new data: data }
 
   describe '#duration' do
+    context 'given a content_detail with duration in weeks, days, hours, minutes' do
+      let(:data) { {"duration"=>"P1W2DT6H21M32S"}}
+      it { expect(content_detail.duration).to eq 800492 }
+    end
+
+    context 'given a content_detail with duration in days' do
+      let(:data) { {"duration"=>"P1D"}}
+      it { expect(content_detail.duration).to eq 86400 }
+    end
+
     context 'given a content_detail with duration in hours, minutes, seconds' do
       let(:data) { {"duration"=>"PT1H18M52S"} }
       it { expect(content_detail.duration).to eq 4732 }


### PR DESCRIPTION
YouTube API does not fully respect ISO 8601 duration standard when
returning the "duration" of a video. This commit adds support for
videos with "days" and "weeks" in their duration which, although not
part of ISO 8601, are sometimes returned by YouTube API.
