### PR TITLE
.size doesn’t load all the pages of collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,31 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-## 0.10.0 - Unreleased
+## 0.10.0 - 2014-08-11
 
+**How to upgrade**
+
+If your code never calls the `size` method to count how many items a list of
+results has (e.g., how many videos an account has), then you are good to go.
+
+If it does, then be aware that `size` will now return try to the number of
+items as specified in the "totalResults" field of the first page of the YouTube
+response, rather than loading *all* the pages (possibly thousands) and counting
+exactly how many items are returned.
+
+If this is acceptable, then you are good to go.
+If you want the old behavior, replace `size` with `count`:
+
+```ruby
+account = Yt::Account.new access_token: 'ya29...'
+# old behavior
+account.videos.size # => retrieved *all* the pages of the account’s videos
+# new behavior
+account.videos.size # => retrieves only the first page, returning the totalResults counter
+account.videos.count # => retrieves *all* the pages of the account’s videos
+```
+
+* [ENHANCEMENT] Calling `size` on a collection does not load all the pages of the collection
 * [ENHANCEMENT] Alias `policy.time_updated` to more coherent `policy.updated_at`
 
 ## 0.9.8 - 2014-08-11
@@ -121,18 +144,21 @@ If your code never declares instances of `Yt::Channel`, or never calls the
 
 If it does, then be aware that `subscribe` will not raise an error anymore if
 a YouTube user tries to subscribe to her/his own YouTube channel. Instead,
-`subscribe` will simply return `nil`. If this is acceptable, then you are good
-to go. If you want the old behavior, replace `subscribe` with `subscribe!`:
+`subscribe` will simply return `nil`.
+
+If this is acceptable, then you are good to go.
+If you want the old behavior, replace `subscribe` with `subscribe!`:
 
 ```ruby
 account = Yt::Account.new access_token: 'ya29...'
 channel = account.channel
 # old behavior
-channel.subscribe # => raise error
+channel.subscribe # => raised an error
 # new behavior
 channel.subscribe # => nil
-channel.subscribe! # => raise error
+channel.subscribe! # => raises an error
 ```
+
 * [ENHANCEMENT] `channel.subscribe` does not raise error when trying to subscribe to one’s own channel
 
 ## 0.7 - 2014/06/18

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.9.8)
+    yt (0.10.0)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.9.8'
+    gem 'yt', '~> 0.10.0'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/collections/annotations.rb
+++ b/lib/yt/collections/annotations.rb
@@ -46,6 +46,15 @@ module Yt
         expected?(error) ? [] : raise(error)
       end
 
+      # @private
+      # @note Annotations overwrites +total_results+ since `items_key` is
+      #   not `items` for annotations.
+      # @todo Remove this function by extracting the keys used by annotations
+      #   in a method and reusing them both in `next_page` and `total_results`.
+      def total_results
+        count
+      end
+
       # Since there is no API endpoint, retrieving annotations of unknown
       # videos or of private videos (to which YouTube responds with 403)
       # should not raise an error, but simply not return any annotation.

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.9.8'
+  VERSION = '0.10.0'
 end

--- a/spec/collections/videos_spec.rb
+++ b/spec/collections/videos_spec.rb
@@ -6,9 +6,22 @@ describe Yt::Collections::Videos do
   subject(:collection) { Yt::Collections::Videos.new parent: channel }
   let(:channel) { Yt::Channel.new id: 'any-id' }
   let(:page) { {items: [], token: 'any-token'} }
-  let(:query) { {q: 'search string'} }
+
+  describe '#size' do
+    describe 'sends only one request and return the total results' do
+      let(:total_results) { 123456 }
+      before do
+        expect_any_instance_of(Yt::Request).to receive(:run).once do
+          double(body: {'pageInfo'=>{'totalResults'=>total_results}})
+        end
+      end
+      it { expect(collection.size).to be total_results }
+    end
+  end
 
   describe '#count' do
+    let(:query) { {q: 'search string'} }
+
     context 'called once with .where(query) and once without' do
       after do
         collection.where(query).count

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -42,12 +42,15 @@ describe Yt::Channel, :device_app do
       it { expect(channel.unsubscribe!).to be_truthy }
     end
 
-    # NOTE: These tests are slow because they go through multiple pages of
-    # results and do so to test that we can overcome YouTube’s limitation of
-    # only returning the first 500 results for each query.
+    # @note: these tests are slow because they go through multiple pages of
+    #   results and do so to test that we can overcome YouTube’s limitation of
+    #   only returning the first 500 results for each query.
+    # @note: in principle, the following three counters should match, but in
+    #   reality +video_count+ and +size+ are only approximations.
     context 'with more than 500 videos' do
       let(:id) { 'UCsmvakQZlvGsyjyOhmhvOsw' }
       it { expect(channel.video_count).to be > 500 }
+      it { expect(channel.videos.size).to be > 500 }
       it { expect(channel.videos.count).to be > 500 }
     end
   end
@@ -126,7 +129,8 @@ describe Yt::Channel, :device_app do
       # NOTE: This test is just a reflection of YouTube irrational behavior of
       # returns 0 results if the name of an unknown channel starts with UC, but
       # returning 100,000 results otherwise (ignoring the channel filter).
-      it { expect(channel.videos.count).to be 0 }
+      it { expect(channel.videos.count).to be_zero }
+      it { expect(channel.videos.size).to be_zero }
     end
   end
 end

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -3,8 +3,7 @@ require 'yt/models/content_owner'
 
 describe Yt::ContentOwner, :partner do
   describe '.partnered_channels' do
-    # NOTE: Uncomment once size does not runs through *all* the pages
-    # it { expect($content_owner.partnered_channels.size).to be > 0 }
+    it { expect($content_owner.partnered_channels.size).to be > 0 }
     it { expect($content_owner.partnered_channels.first).to be_a Yt::Channel }
   end
 

--- a/spec/requests/as_server_app/channel_spec.rb
+++ b/spec/requests/as_server_app/channel_spec.rb
@@ -36,7 +36,8 @@ describe Yt::Channel, :server_app do
       # NOTE: This test is just a reflection of YouTube irrational behavior of
       # returns 0 results if the name of an unknown channel starts with UC, but
       # returning 100,000 results otherwise (ignoring the channel filter).
-      it { expect(channel.videos.count).to be 0 }
+      it { expect(channel.videos.count).to be_zero }
+      it { expect(channel.videos.size).to be_zero }
     end
   end
 end

--- a/spec/requests/unauthenticated/video_spec.rb
+++ b/spec/requests/unauthenticated/video_spec.rb
@@ -9,6 +9,7 @@ describe Yt::Video do
 
     it { expect(video.annotations).to be_a Yt::Collections::Annotations }
     it { expect(video.annotations.first).to be_a Yt::Annotation }
+    it { expect(video.annotations.size).to be > 0 }
   end
 
   context 'given a private video' do
@@ -16,5 +17,6 @@ describe Yt::Video do
 
     it { expect(video.annotations).to be_a Yt::Collections::Annotations }
     it { expect(video.annotations.count).to be_zero }
+    it { expect(video.annotations.size).to be_zero }
   end
 end


### PR DESCRIPTION
Calling `size` on a collection (for instance on account.videos to know the
number of videos owned by an account) will now return the number of items as
specified in the "totalResults" field of the first page of the YouTube
response, rather than loading _all_ the pages (possibly thousands) and counting
exactly how many items are returned.

The old behavior is kept the same for the `count` method.
