### PR TITLE
Alias `policy.time_updated` to `policy.updated_at`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.10.0 - Unreleased
+
+* [ENHANCEMENT] Alias `policy.time_updated` to more coherent `policy.updated_at`
+
 ## 0.9.8 - 2014-08-11
 
 * [FEATURE] Add `.content_owner` and `.linked_at` to channels managed by a CMS content owner

--- a/lib/yt/models/policy.rb
+++ b/lib/yt/models/policy.rb
@@ -29,9 +29,10 @@ module Yt
       end
 
       # @return [String] the time the policy was updated.
-      def time_updated
-        @time_updated ||= Time.parse @data['timeUpdated']
+      def updated_at
+        @updated_at ||= Time.parse @data['timeUpdated']
       end
+      alias time_updated updated_at
 
       # @return [Array<PolicyRule>] a list of rules that specify the action
       #   that YouTube should take and may optionally specify the conditions

--- a/spec/models/policy_spec.rb
+++ b/spec/models/policy_spec.rb
@@ -25,10 +25,10 @@ describe Yt::Policy do
     end
   end
 
-  describe '#time_updated' do
+  describe '#updated_at' do
     context 'given fetching a policy returns a timeUpdated' do
       let(:data) { {"timeUpdated"=>"1970-01-16T20:33:03.675Z"} }
-      it { expect(policy.time_updated.year).to be 1970 }
+      it { expect(policy.updated_at.year).to be 1970 }
     end
   end
 

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -129,7 +129,7 @@ describe Yt::ContentOwner, :partner do
       it 'returns valid metadata' do
         expect(policy.id).to be_a String
         expect(policy.name).to be_a String
-        expect(policy.time_updated).to be_a Time
+        expect(policy.updated_at).to be_a Time
         expect(rule.action).to  be_in Yt::PolicyRule::ACTIONS
         expect(rule.included_territories).to be_an Array
         expect(rule.excluded_territories).to be_an Array


### PR DESCRIPTION
This is more coherent with the other timestamp attributes.
