### PR TITLE
Add references.insert to references collection

### DIFF
--- a/lib/yt/actions/insert.rb
+++ b/lib/yt/actions/insert.rb
@@ -7,6 +7,9 @@ module Yt
     private
 
       def do_insert(extra_insert_params = {})
+        camelize_keys! extra_insert_params[:body] if extra_insert_params[:body] && insert_params.fetch(:camelize_body, true)
+        camelize_keys! extra_insert_params[:params] if extra_insert_params[:params] && insert_params.fetch(:camelize_params, true)
+
         request = Yt::Request.new insert_params.deep_merge(extra_insert_params)
         response = request.run
         @items = []
@@ -21,12 +24,21 @@ module Yt
           params[:method] = :post
           params[:auth] = @auth
           params[:expected_response] = Net::HTTPOK
+          params[:camelize_params] = true
+          params[:camelize_body] = true
         end
       end
 
       def extract_data_from(response)
         response.body
       end
+
+      def camelize_keys!(hash = {})
+        hash.dup.each_key do |key|
+          hash[key.to_s.camelize(:lower).to_sym] = hash.delete key
+        end
+      end
+
     end
   end
 end

--- a/lib/yt/collections/references.rb
+++ b/lib/yt/collections/references.rb
@@ -8,6 +8,12 @@ module Yt
     # Resources with references are: {Yt::Models::ContentOwner content owners}.
     class References < Base
 
+      def insert(options = {})
+        params = {onBehalfOfContentOwner: @parent.owner_name}.merge options.slice :claimId, :claim_id
+        body = options.except :claimId, :claim_id
+        do_insert(params: params, body: body)
+      end
+
     private
 
       def new_item(data)
@@ -24,9 +30,18 @@ module Yt
         end
       end
 
+      # @return [Hash] the parameters to submit to YouTube to add a reference.
+      # @see https://developers.google.com/youtube/partner/docs/v1/references/insert
+      def insert_params
+        super.tap do |params|
+          params[:path] = '/youtube/partner/v1/references'
+        end
+      end
+
       def references_params
         apply_where_params! on_behalf_of_content_owner: @parent.owner_name
       end
+
     end
   end
 end


### PR DESCRIPTION
Adds the ability to create reference files via an existing claim.

@claudiofullscreen Don't attempt to test this without talking to me first.  Creating reference files in the CMS should not be done without caution.

This adds some shared functionality from Actions::List which should probably be DRY-ed up.

Allows for creation of references **from an existing claim** :

``` ruby
content_owner.references.insert(claim_id: 'abcd', content_type: 'audiovisual') #=> #<Yt::Models::Reference
```
