### PR TITLE
Add Assets and AssetMatchPolicy

### DIFF
--- a/lib/yt/collections/assets.rb
+++ b/lib/yt/collections/assets.rb
@@ -1,0 +1,32 @@
+require 'yt/collections/base'
+require 'yt/models/asset'
+
+module Yt
+  module Collections
+    # Provides methods to interact with a collection of Content ID assets.
+    #
+    # Resources with assets are: {Yt::Models::ContentOwner content owners}.
+    class Assets < Base
+
+    private
+
+      def new_item(data)
+        Yt::Asset.new data: data, auth: @auth
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to list assets
+      #   owned by the content owner.
+      # @see https://developers.google.com/youtube/partner/docs/v1/assets/list
+      def list_params
+        super.tap do |params|
+          params[:params] = assets_params
+          params[:path] = '/youtube/partner/v1/assets'
+        end
+      end
+
+      def assets_params
+        apply_where_params! on_behalf_of_content_owner: @parent.owner_name
+      end
+    end
+  end
+end

--- a/lib/yt/models/asset.rb
+++ b/lib/yt/models/asset.rb
@@ -1,0 +1,121 @@
+require 'yt/models/base'
+require 'yt/models/asset_match_policy'
+
+module Yt
+  module Models
+    # Provides methods to interact with YouTube ContentID assets.
+    # @see https://developers.google.com/youtube/partner/docs/v1/assets
+    class Asset < Base
+      def initialize(options = {})
+        @data = options[:data]
+        @auth = options[:auth]
+      end
+
+      # @return [String] the ID that YouTube assigns and uses to uniquely
+      #   identify the asset.
+      def id
+        @id ||= @data['id']
+      end
+
+      # @return [AssetMatchPolicy] the match policy set by the default
+      #   content owner for the currently authenticated user.
+      def match_policy
+        @asset_match_policy ||= if @data['matchPolicy']
+          AssetMatchPolicy.new data: @data['matchPolicy'], asset_id: id, auth: @auth
+        end
+      end
+
+# Type
+
+      TYPES = %q(art_track_video composition episode general movie music_video season show sound_recording video_game web)
+
+      # @return [String] the asset's type. Valid values are: art_track_video
+      #   composition, episode, general, movie, music_video, season
+      #   show sound_recording, video_game, web
+      def type
+        @type ||= @data["type"]
+      end
+
+      # @return [Boolean] whether the asset is of type art_track_video
+      def art_track_video?
+        type == 'art_track_video'
+      end
+
+      # @return [Boolean] whether the asset is of type art_track_video
+      def composition?
+        type == 'composition'
+      end
+
+      # @return [Boolean] whether the asset is of type episode
+      def episode?
+        type == 'episode'
+      end
+
+      # @return [Boolean] whether the asset is of type general
+      def general?
+        type == 'general'
+      end
+
+      # @return [Boolean] whether the asset is of type movie
+      def movie?
+        type == 'movie'
+      end
+
+      # @return [Boolean] whether the asset is of type music_video
+      def music_video?
+        type == 'music_video'
+      end
+
+      # @return [Boolean] whether the asset is of type season
+      def season?
+        type == 'season'
+      end
+
+      # @return [Boolean] whether the asset is of type show
+      def show?
+        type == 'show'
+      end
+
+      # @return [Boolean] whether the asset is of type sound_recording
+      def sound_recording?
+        type == 'sound_recording'
+      end
+
+      # @return [Boolean] whether the asset is of type video_game
+      def video_game?
+        type == 'video_game'
+      end
+
+      # @return [Boolean] whether the asset is of type web
+      def web?
+        type == 'web'
+      end
+
+# Status
+
+      STATUSES = %q(active inactive pending)
+
+      # @return [String] the asset's status. Valid values are: active,
+      #    inactive, pending
+      def status
+        @status ||= @data["status"]
+      end
+
+      # @return [Boolean] whether the asset is active.
+      def active?
+        status == 'active'
+      end
+
+      # @return [Boolean] whether the asset is inactive.
+      def inactive?
+        status == 'inactive'
+      end
+
+      # @return [Boolean] whether the asset is pending.
+      def pending?
+        status == 'pending'
+      end
+
+    end
+  end
+end

--- a/lib/yt/models/asset_match_policy.rb
+++ b/lib/yt/models/asset_match_policy.rb
@@ -1,0 +1,65 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # Provides methods to interact with YouTube ContentID asset match
+    # policies which YouTube applies to user-uploaded videos that match
+    # the asset.
+    # @see https://developers.google.com/youtube/partner/docs/v1/assetMatchPolicy
+    class AssetMatchPolicy < Resource
+      def initialize(options = {})
+        @data = options[:data]
+        @asset_id = options[:asset_id]
+        @auth = options[:auth]
+      end
+
+      def update(attributes = {})
+        camelize_keys! attributes
+
+        do_update params: {onBehalfOfContentOwner: @auth.owner_name}, body: attributes do |data|
+          @data = data
+          @policy_id = nil
+          @rules = nil
+          true
+        end
+      end
+
+      # @return [String] A value that uniquely identifies the Asset
+      #   resource which contains this match policy
+      def asset_id
+        @asset_id
+      end
+
+      # @return [String] A value that uniquely identifies the Policy
+      #   resource that YouTube applies to user-uploaded videos that
+      #   match the asset.
+      def policy_id
+        @policy_id ||= @data['policyId']
+      end
+
+      # @return [Array<PolicyRule>] A list of rules that collectively
+      #   define the policy that the content owner wants to apply to
+      #   user-uploaded videos that match the asset. Each rule specifies
+      #   the action that YouTube should take and may optionally specify
+      #   the conditions under which that action is enforced.
+      def rules
+        @rules ||= @data.fetch('rules', []).map{|rule| PolicyRule.new data: rule}
+      end
+
+      private
+
+      def update_params
+        super.tap do |params|
+          params[:path] = "/youtube/partner/v1/assets/#{asset_id}/matchPolicy"
+        end
+      end
+
+      def camelize_keys!(hash = {})
+        hash.dup.each_key do |key|
+          hash[key.to_s.camelize(:lower).to_sym] = hash.delete key
+        end
+      end
+
+    end
+  end
+end

--- a/lib/yt/models/content_owner.rb
+++ b/lib/yt/models/content_owner.rb
@@ -23,6 +23,10 @@ module Yt
       #   @return [Yt::Collection::Policies] the policies saved by the content owner.
       has_many :policies
 
+      # @!attribute [r] assets
+      #   @return [Yt::Collection::Assets] the assets owned by the content owner.
+      has_many :assets
+
       def initialize(options = {})
         super options
         @owner_name = options[:owner_name]

--- a/lib/yt/models/resource.rb
+++ b/lib/yt/models/resource.rb
@@ -86,6 +86,12 @@ module Yt
         hash.dup.each_key{|key| hash[underscore key] = hash.delete key}
       end
 
+      def camelize_keys!(hash)
+        hash.dup.each_key do |key|
+          hash[key.to_s.camelize(:lower).to_sym] = hash.delete key
+        end
+      end
+
       # @return [Hash] the original hash with angle brackets characters in its
       #   values replaced with similar Unicode characters accepted by Youtube.
       # @see https://support.google.com/youtube/answer/57404?hl=en


### PR DESCRIPTION
- [x] Add Assets
- [x] Add AssetMatchPolicy
- [x] Allow for updates to match policy

``` ruby
asset = content_owner.assets.where(id: 'A824442156859073', fetch_match_policy: 'mine').first #=> #<Yt::Models::Asset
asset.match_policy.policy_id #=> "aVzeRV6u-AM"
asset.match_policy.update(policy_id: 'ZNC0Fr9ipUI') #=> true
asset.match_policy.policy_id #=> "ZNC0Fr9ipUI"
```

The asset model is far from complete, but I would hopefully like to get this merged without completing the entire model architecture (it's big).

Could use some DRYing.

@claudiofullscreen Let's work together to prioritize some of the outstanding PRs.
