### PR TITLE
Add #match_reference_id to claim model

### DIFF
--- a/lib/yt/models/claim.rb
+++ b/lib/yt/models/claim.rb
@@ -131,6 +131,12 @@ module Yt
       def block_outside_ownership?
         @block_outside_ownership ||= @data["blockOutsideOwnership"]
       end
+
+      # @return [String] The unique ID that YouTube uses to identify the
+      #   reference that generated the match.
+      def match_reference_id
+        @match_reference_id ||= @data.fetch('matchInfo', {})['referenceId']
+      end
     end
   end
 end

--- a/spec/models/claim_spec.rb
+++ b/spec/models/claim_spec.rb
@@ -190,6 +190,13 @@ describe Yt::Claim do
     end
   end
 
+  describe '#match_reference_id' do
+    context 'given fetching a claim returns matchInfo' do
+      let(:data) { {"matchInfo"=>{"referenceId"=>"0r3JDtcRLuQ"}} }
+      it { expect(claim.match_reference_id).to eq "0r3JDtcRLuQ" }
+    end
+  end
+
   describe '#third_party?' do
     context 'given fetching a claim returns thirdPartyClaim true' do
       let(:data) { {"thirdPartyClaim"=>true} }


### PR DESCRIPTION
For claims that were created from a match associated with a YouTube reference file, the claim returns a `matchInfo` block.

``` ruby
content_owner.owner_name #=> "Fullscreen_managed"
content_owner.claims.where(id: "0r3JDtcRLuQ").first.match_reference_id #=> "idfTmlwSOGE"
```
### Documentation

https://developers.google.com/youtube/partner/docs/v1/claims#matchInfo
### YouTube API response:

``` json
{
 "kind": "youtubePartner#claimList",
 "pageInfo": {
  "totalResults": 1
 },
 "items": [
  {

   "kind": "youtubePartner#claim",
   "id": "0r3JDtcRLuQ",
   "assetId": "A156933526222889",
   "videoId": "qCfOdD8Pnow",
   "policy": {
    "kind": "youtubePartner#policy",
    "id": "S757160351202795",
    "name": "Monetize in all countries",
    "rules": [
     {
      "action": "monetize"
     }
    ]
   },
   "status": "active",
   "contentType": "audiovisual",
   "timeCreated": "2014-08-10T12:16:39.000Z",
   "blockOutsideOwnership": false,
   "matchInfo": {
    "referenceId": "idfTmlwSOGE",
    "longestMatch": {
     "durationSecs": "72",
     "userVideoOffset": "1",
     "referenceOffset": "1"
    },
    "totalMatch": {
     "userVideoDurationSecs": "72",
     "referenceDurationSecs": "72"
    }
   },
   "origin": {
    "source": "videoMatch"
   }
  }
 ]
}
```
