### PR TITLE
Add methods to insert and delete references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.10.3 - 2014-08-12
+
+* [FEATURE] Add methods to insert and delete ContentID references
+* [FEATURE] Add `.match_reference_id` to Claim model
+
 ## 0.10.2 - 2014-08-11
 
 * [FEATURE] Add `MatchPolicy` class with `.update` to change the policy used by an asset

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.10.2)
+    yt (0.10.3)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.10.2'
+    gem 'yt', '~> 0.10.3'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/models/content_owner.rb
+++ b/lib/yt/models/content_owner.rb
@@ -27,6 +27,10 @@ module Yt
         super options
         @owner_name = options[:owner_name]
       end
+
+      def create_reference(params = {})
+        references.insert params
+      end
     end
   end
 end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.10.2'
+  VERSION = '0.10.3'
 end


### PR DESCRIPTION
Content owners can now create references pointing to existing claims with

```
content_owner.create_reference claim_id: 'CLAIM123', content_type: 'audiovisual'
```

References can also be "soft" deleted with:

```
reference = Yt::Reference.new id: 'REF123', auth: content_owner
reference.delete
```

This "soft" deletion sets the status to "inactive" (YouTube does not provide a
method for really deleting a Reference).
