### PR TITLE
List tags of videos retrieved with Video#search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.10.4 - 2014-08-15
+
+* [BUGFIX] List tags of videos retrieved with channel.videos and account.videos
+
 ## 0.10.3 - 2014-08-12
 
 * [FEATURE] Add methods to insert and delete ContentID references

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    yt (0.10.3)
+    yt (0.10.4)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.10.3'
+    gem 'yt', '~> 0.10.4'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -13,9 +13,14 @@ module Yt
 
       # @return [Yt::Models::Video] a new video initialized with one of
       #   the items returned by asking YouTube for a list of videos.
+      # According to the documentation, tags are only visible to the video's
+      # uploader, and are not returned when search for all the videos of an
+      # account. Instead, a separate call to Videos#list is required. Setting
+      # +includes_tags+ to +false+ makes sure that `video.tags` will do this.
       # @see https://developers.google.com/youtube/v3/docs/videos#resource
       def new_item(data)
-        Yt::Video.new id: data['id']['videoId'], snippet: data['snippet'], auth: @auth
+        snippet = data.fetch('snippet', {}).merge includes_tags: false
+        Yt::Video.new id: data['id']['videoId'], snippet: snippet, auth: @auth
       end
 
       # @return [Hash] the parameters to submit to YouTube to list videos.

--- a/lib/yt/models/snippet.rb
+++ b/lib/yt/models/snippet.rb
@@ -162,6 +162,18 @@ module Yt
       def video
         @video ||= Video.new id: video_id, auth: @auth if video_id
       end
+
+      # Returns whether YouTube API includes tags in this snippet.
+      # YouTube API only returns tags on Videos#list, not on Videos#search.
+      # This method is used to guarantee that, when a video was instantiated
+      # by calling account.videos or channel.videos, then video.tags is not
+      # simply returned as empty, but an additional call to Videos#list is
+      # made to retrieve the correct tags.
+      # @see https://developers.google.com/youtube/v3/docs/videos
+      # @return [Boolean] whether YouTube API includes tags in this snippet.
+      def includes_tags
+        @includes_tags ||= @data.fetch :includes_tags, true
+      end
     end
   end
 end

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -5,7 +5,7 @@ module Yt
     # Provides methods to interact with YouTube videos.
     # @see https://developers.google.com/youtube/v3/docs/videos
     class Video < Resource
-      delegate :tags, :channel_id, :channel_title, :category_id,
+      delegate :channel_id, :channel_title, :category_id,
         :live_broadcast_content, to: :snippet
 
       delegate :deleted?, :failed?, :processed?, :rejected?, :uploaded?,
@@ -66,6 +66,19 @@ module Yt
       has_one :statistics_set
       delegate :view_count, :like_count, :dislike_count, :favorite_count,
         :comment_count, to: :statistics_set
+
+      # Returns the list of keyword tags associated with the video.
+      # Since YouTube API only returns tags on Videos#list, the memoized
+      # @snippet is erased if the video was instantiated through Video#search
+      # (e.g., by calling account.videos or channel.videos), so that the full
+      # snippet (with tags) is loaded, rather than the partial one.
+      # @see https://developers.google.com/youtube/v3/docs/videos
+      # @return [Array<Yt::Models::Tag>] the list of keyword tags associated
+      #   with the video.
+      def tags
+        @snippet = nil unless snippet.includes_tags
+        snippet.tags
+      end
 
       # Deletes the video.
       #

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.10.3'
+  VERSION = '0.10.4'
 end

--- a/spec/requests/as_account/account_spec.rb
+++ b/spec/requests/as_account/account_spec.rb
@@ -11,8 +11,12 @@ describe Yt::Account, :device_app do
   end
 
   describe '.videos' do
-    it { expect($account.videos).to be_a Yt::Collections::Videos }
-    it { expect($account.videos.where(order: 'viewCount').first).to be_a Yt::Video }
+    let(:video) { $account.videos.where(order: 'viewCount').first }
+
+    specify 'returns the account’s videos with its tags' do
+      expect(video).to be_a Yt::Video
+      expect(video.tags).not_to be_empty
+    end
 
     describe '.where(q: query_string)' do
       let(:count) { $account.videos.where(q: query).count }


### PR DESCRIPTION
YouTube API only returns tags on Videos#list.
To show the tags even for videos instantiated through Video#search
(e.g., by calling account.videos or channel.videos), the partial
snippet is reloaded to obtain the full snippet (with tags),
rather than the partial one.
