### PR TITLE
Add support for PATCH requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.10.5 - unreleased
+
+* [ENHANCEMENT] Use PATCH rather than PUT to partially update a MatchPolicy
+
 ## 0.10.4 - 2014-08-15
 
 * [BUGFIX] List tags of videos retrieved with channel.videos and account.videos

--- a/lib/yt/actions/patch.rb
+++ b/lib/yt/actions/patch.rb
@@ -1,0 +1,19 @@
+require 'yt/actions/modify'
+
+module Yt
+  module Actions
+    module Patch
+      include Modify
+
+    private
+
+      def do_patch(extra_patch_params = {}, &block)
+        do_modify patch_params.deep_merge(extra_patch_params), &block
+      end
+
+      def patch_params
+        modify_params.tap{|params| params[:method] = :patch}
+      end
+    end
+  end
+end

--- a/lib/yt/models/base.rb
+++ b/lib/yt/models/base.rb
@@ -1,5 +1,6 @@
 require 'yt/actions/delete'
 require 'yt/actions/update'
+require 'yt/actions/patch'
 
 require 'yt/associations/has_authentication'
 require 'yt/associations/has_many'
@@ -14,6 +15,7 @@ module Yt
     class Base
       include Actions::Delete
       include Actions::Update
+      include Actions::Patch
 
       extend Associations::HasReports
       extend Associations::HasViewerPercentages

--- a/lib/yt/models/match_policy.rb
+++ b/lib/yt/models/match_policy.rb
@@ -11,19 +11,18 @@ module Yt
         @auth = options[:auth]
       end
 
-      # @note Only policyId can be currently updated, not rules.
       def update(attributes = {})
         underscore_keys! attributes
-        do_update body: {policyId: attributes[:policy_id]}
+        do_patch body: {policyId: attributes[:policy_id]}
         true
       end
 
     private
 
-      # @return [Hash] the parameters to submit to YouTube to update an asset
+      # @return [Hash] the parameters to submit to YouTube to patch an asset
       #   match policy.
-      # @see https://developers.google.com/youtube/partner/docs/v1/assetMatchPolicy/update
-      def update_params
+      # @see https://developers.google.com/youtube/partner/docs/v1/assetMatchPolicy/patch
+      def patch_params
         super.tap do |params|
           params[:path] = "/youtube/partner/v1/assets/#{@asset_id}/matchPolicy"
           params[:params] = {onBehalfOfContentOwner: @auth.owner_name}


### PR DESCRIPTION
Currently only YouTube Partners API supports PATCH, while YouTube
Data API still only has support for PUT requests to update resources.

The Patch action is introduced and used in the only Partner resource
that can get updated by Yt so far: MatchPolicy.
