### PR TITLE
Add Yt::Search.

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,20 @@ item.delete #=> true
 
 *The methods above require to be authenticated as the playlist’s owner (see below).*
 
+Yt::Search
+----------
+
+Use [Yt::Search](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models/Search) to
+
+* find videos matching a user's query
+
+```ruby
+search = Yt::Search.new 'railsconf 2014 keynote'
+search.videos.first #=> #<Yt::Models::Video @id=...>
+```
+
+*The methods above do not require authentication.*
+
 
 Yt::Annotation
 --------------

--- a/lib/yt.rb
+++ b/lib/yt.rb
@@ -6,6 +6,7 @@ require 'yt/models/content_owner'
 require 'yt/models/match_policy'
 require 'yt/models/playlist'
 require 'yt/models/playlist_item'
+require 'yt/models/search'
 require 'yt/models/video'
 
 # An object-oriented Ruby client for YouTube.

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -52,7 +52,7 @@ module Yt
           params[:type] = :video
           params[:max_results] = 50
           params[:part] = 'snippet'
-          params[:order] = 'date'
+          params[:order] ||= 'date'
           params[:published_before] = @published_before if @published_before
           apply_where_params! params
         end

--- a/lib/yt/models/search.rb
+++ b/lib/yt/models/search.rb
@@ -1,0 +1,33 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # A video search.
+    # @see https://developers.google.com/youtube/v3/docs/search/list
+    class Search < Base
+      attr_reader :auth
+
+      def initialize(query, options = {})
+        @query = query
+
+        @auth = options[:auth]
+        @order = options[:order] || 'relevance'
+        @safe_search = options[:safe_search] || 'moderate'
+      end
+
+      # @!attribute [r] videos
+      #   @return [Yt::Collections::Videos] the videos returned by the search
+      has_many :videos
+
+      # @private
+      # Tells `has_many :videos` what params to use in the /list API call.
+      def videos_params
+        {
+          q: @query,
+          order: @order,
+          safe_search: @safe_search
+        }
+      end
+    end
+  end
+end

--- a/spec/requests/as_server_app/search_spec.rb
+++ b/spec/requests/as_server_app/search_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require 'yt/models/search'
+
+describe Yt::Search, :server_app do
+  subject(:search) { Yt::Search.new query  }
+
+  context 'given a specific query' do
+    let(:query) { 'railsconf 2014 keynote' }
+
+    it { expect(search.videos).to be_a Yt::Collections::Videos }
+
+    it 'returns at least one result' do
+      expect(search.videos.first).to be_a Yt::Video
+    end
+  end
+end


### PR DESCRIPTION
Thank you very much for putting this gem together! I'm glad to see a gem that uses the V3 API!

I looked through the docs and code, and to the best of my knowledge, there's no way of doing a keyword search. The plumbing for using `GET /search` is all there, but it seems to only be exposed in the context of retrieving the videos in a channel or account.

This PR adds a Search model that can be used to run a keyword query. It's very bare-bones, because I wanted to get your opinion before I sink more time into it. At the same time, it is covered by tests, and I'm using it successfully in an application.

What do you think?  
