### PR TITLE
added asset, assets, ownership, and claims.insert to support changing mo...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.11.2 - 2014-08-19
+
+* [FEATURE] Add Assets Collection
+* [FEATURE] Add Asset model
+* [FEATURE] Add Ownership model
+* [FEATURE] Add VideoAdvertisingOptions model
+
 ## 0.11.1 - 2014-08-17
 
 * [ENHANCEMENT] Add Video search even without a parent account or channel

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.11.1'
+    gem 'yt', '~> 0.11.2'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt.rb
+++ b/lib/yt.rb
@@ -7,6 +7,7 @@ require 'yt/models/match_policy'
 require 'yt/models/playlist'
 require 'yt/models/playlist_item'
 require 'yt/models/video'
+require 'yt/models/ownership'
 
 # An object-oriented Ruby client for YouTube.
 # Helps creating applications that need to interact with YouTube objects.

--- a/lib/yt.rb
+++ b/lib/yt.rb
@@ -8,6 +8,7 @@ require 'yt/models/playlist'
 require 'yt/models/playlist_item'
 require 'yt/models/video'
 require 'yt/models/ownership'
+require 'yt/models/video_advertising_options'
 
 # An object-oriented Ruby client for YouTube.
 # Helps creating applications that need to interact with YouTube objects.

--- a/lib/yt/actions/get.rb
+++ b/lib/yt/actions/get.rb
@@ -1,0 +1,28 @@
+require 'yt/models/request'
+
+module Yt
+  module Actions
+    # Abstract module that contains method for getting
+    module Get
+
+    private
+
+      def do_get(params = {})
+        request = Yt::Request.new get_params.deep_merge(params)
+        response = request.run
+        yield response.body if block_given?
+      end
+
+      def get_params
+        path = "/youtube/v3/#{self.class.to_s.demodulize.pluralize.camelize :lower}"
+
+        {}.tap do |params|
+          params[:method] = :get
+          params[:path] = path
+          params[:auth] = @auth
+          params[:expected_response] = Net::HTTPOK
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/collections/assets.rb
+++ b/lib/yt/collections/assets.rb
@@ -1,0 +1,61 @@
+require 'yt/collections/base'
+require 'yt/models/asset'
+
+module Yt
+  module Collections
+    # Provides methods to interact with a collection of Content ID assets.
+    #
+    # Resources with assets are: {Yt::Models::ContentOwner content owners}.
+    class Assets < Base
+      def insert(attributes = {})
+        underscore_keys! attributes
+        body = {  type: attributes[:type], 
+                  metadata: attributes[:metadata]
+        }
+        params = {onBehalfOfContentOwner: @auth.owner_name}
+        do_insert(params: params, body: body)
+      end
+
+    private
+
+      def new_item(data)
+        Yt::Asset.new data: data
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to add an asset.
+      # @see https://developers.google.com/youtube/partner/docs/v1/references/insert
+      def insert_params
+        super.tap do |params|
+          params[:path] = '/youtube/partner/v1/assets'
+        end
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to list assets
+      #   administered by the content owner.
+      # @see https://developers.google.com/youtube/partner/docs/v1/assets/list
+      # @see https://developers.google.com/youtube/partner/docs/v1/assetSearch/list
+      def list_params
+        super.tap do |params|
+          params[:path] = assets_path
+          params[:params] = assets_params
+        end
+      end
+
+      def assets_params
+        apply_where_params! on_behalf_of_content_owner: @parent.owner_name
+      end
+
+      # @private
+      # @todo: This is the only place outside of base.rb where @where_params
+      #   is accessed; it should be replaced with a filter on params instead.
+      def assets_path
+        @where_params ||= {}
+        if @where_params.key?(:id)
+          '/youtube/partner/v1/assets'
+        else
+          '/youtube/partner/v1/assetSearch'
+        end
+      end
+    end
+  end
+end

--- a/lib/yt/collections/base.rb
+++ b/lib/yt/collections/base.rb
@@ -46,6 +46,16 @@ module Yt
       def apply_where_params!(params = {})
         params.merge!(@where_params ||= {})
       end
+
+      # If we dropped support for ActiveSupport 3, then we could simply
+      # invoke transform_keys!{|key| key.to_s.underscore.to_sym}
+      def underscore_keys!(hash)
+        hash.dup.each_key{|key| hash[underscore key] = hash.delete key}
+      end
+
+      def underscore(value)
+        value.to_s.underscore.to_sym
+      end
     end
   end
 end

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -11,7 +11,7 @@ module Yt
         underscore_keys! attributes
         body = {  assetId: attributes[:asset_id],
                   videoId: attributes[:video_id],
-                  policy: attributes[:policy],
+                  policy: {id: attributes[:policy_id]},
                   contentType: attributes[:content_type]
         }
         params = {onBehalfOfContentOwner: @auth.owner_name}

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -7,11 +7,29 @@ module Yt
     #
     # Resources with claims are: {Yt::Models::ContentOwner content owners}.
     class Claims < Base
+      def insert(attributes = {})
+        underscore_keys! attributes
+        body = {  assetId: attributes[:asset_id],
+                  videoId: attributes[:video_id],
+                  policy: attributes[:policy],
+                  contentType: attributes[:content_type]
+        }
+        params = {onBehalfOfContentOwner: @auth.owner_name}
+        do_insert(params: params, body: body)
+      end
 
     private
 
       def new_item(data)
         Yt::Claim.new data: data
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to add a claim.
+      # @see https://developers.google.com/youtube/partner/docs/v1/claims/insert
+      def insert_params
+        super.tap do |params|
+          params[:path] = '/youtube/partner/v1/claims'
+        end
       end
 
       # @return [Hash] the parameters to submit to YouTube to list claims

--- a/lib/yt/collections/references.rb
+++ b/lib/yt/collections/references.rb
@@ -41,6 +41,7 @@ module Yt
       def references_params
         apply_where_params! on_behalf_of_content_owner: @parent.owner_name
       end
+
     end
   end
 end

--- a/lib/yt/collections/resources.rb
+++ b/lib/yt/collections/resources.rb
@@ -73,6 +73,7 @@ module Yt
       def camelize(value)
         value.to_s.camelize(:lower).to_sym
       end
+
     end
   end
 end

--- a/lib/yt/models/asset.rb
+++ b/lib/yt/models/asset.rb
@@ -1,0 +1,44 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # Provides methods to interact with YouTube ContentID assets.
+    # @see https://developers.google.com/youtube/partner/docs/v1/assets
+    class Asset < Base
+      def initialize(options = {})
+        @data = options[:data]
+      end
+
+      # @return [String] the ID that YouTube assigns and uses to uniquely
+      #   identify the asset.
+      def id
+        @id ||= @data['id']
+      end
+
+      # @return [String] The asset's type. This value determines which 
+      # metadata fields might be included in the metadata object.
+      def type
+        @type ||= @data['type']
+      end
+
+      # @return [String] Title of this asset.
+      def title
+        @title ||= @data.fetch "title", nil
+        @title ||= metadata ? metadata.fetch('title', nil) : nil
+      end
+
+      # @return [String] Title of this asset.
+      def customId
+        @customId ||= @data.fetch "customId", nil
+        @customId ||= metadata ? metadata.fetch('customId', nil) : nil
+      end
+
+    private 
+      # @return [Hash] the metadata associated with the asset.
+      def metadata
+        @metadata ||= @data.fetch "metadata", nil
+      end
+
+    end
+  end
+end

--- a/lib/yt/models/base.rb
+++ b/lib/yt/models/base.rb
@@ -22,6 +22,17 @@ module Yt
       extend Associations::HasOne
       extend Associations::HasMany
       extend Associations::HasAuthentication
+
+    private 
+      # If we dropped support for ActiveSupport 3, then we could simply
+      # invoke transform_keys!{|key| key.to_s.underscore.to_sym}
+      def underscore_keys!(hash)
+        hash.dup.each_key{|key| hash[underscore key] = hash.delete key}
+      end
+
+      def underscore(value)
+        value.to_s.underscore.to_sym
+      end
     end
   end
 

--- a/lib/yt/models/content_owner.rb
+++ b/lib/yt/models/content_owner.rb
@@ -15,6 +15,10 @@ module Yt
       #   @return [Yt::Collection::Claims] the claims administered by the content owner.
       has_many :claims
 
+      # @!attribute [r] assets
+      #   @return [Yt::Collection::Assets] the assets administered by the content owner.
+      has_many :assets
+
       # @!attribute [r] references
       #   @return [Yt::Collection::References] the references administered by the content owner.
       has_many :references
@@ -30,6 +34,10 @@ module Yt
 
       def create_reference(params = {})
         references.insert params
+      end
+
+      def create_asset(params = {})
+        assets.insert params
       end
     end
   end

--- a/lib/yt/models/match_policy.rb
+++ b/lib/yt/models/match_policy.rb
@@ -29,6 +29,7 @@ module Yt
           params[:expected_response] = Net::HTTPOK
         end
       end
+
     end
   end
 end

--- a/lib/yt/models/ownership.rb
+++ b/lib/yt/models/ownership.rb
@@ -14,7 +14,7 @@ module Yt
       # update the ownership details
       def update(attributes = {})
         underscore_keys! attributes
-        do_update body: {   kind: attributes[:policy_id],
+        do_update body: {   kind: attributes[:kind],
                             general: attributes[:general]
         }
         true

--- a/lib/yt/models/ownership.rb
+++ b/lib/yt/models/ownership.rb
@@ -1,0 +1,38 @@
+require 'yt/models/base'
+
+module Yt
+  module Models
+    # Provides methods to interact with YouTube ContentID asset ownership,
+    # which provide ownership information for the specified asset.
+    # @see https://developers.google.com/youtube/partner/docs/v1/ownership
+    class Ownership < Base
+      def initialize(options = {})
+        @asset_id = options[:asset_id]
+        @auth = options[:auth]
+      end
+
+      # update the ownership details
+      def update(attributes = {})
+        underscore_keys! attributes
+        do_update body: {   kind: attributes[:policy_id],
+                            general: attributes[:general]
+        }
+        true
+      end
+
+    private
+
+      # @return [Hash] the parameters to submit to YouTube to update an asset
+      #  ownership.
+      # @see https://developers.google.com/youtube/partner/docs/v1/ownership/update
+      def update_params
+        super.tap do |params|
+          params[:path] = "/youtube/partner/v1/assets/#{@asset_id}/ownership"
+          params[:params] = {onBehalfOfContentOwner: @auth.owner_name}
+          params[:expected_response] = Net::HTTPOK
+        end
+      end
+
+    end
+  end
+end

--- a/lib/yt/models/resource.rb
+++ b/lib/yt/models/resource.rb
@@ -94,6 +94,7 @@ module Yt
       def camelize(value)
         value.to_s.camelize(:lower).to_sym
       end
+
     end
   end
 end

--- a/lib/yt/models/video_advertising_options.rb
+++ b/lib/yt/models/video_advertising_options.rb
@@ -1,0 +1,49 @@
+require 'yt/models/base'
+require 'yt/actions/get'
+
+module Yt
+  module Models
+    # The advertising settings for a video. The settings identify the types 
+    # of ads that can run during the video as well as the times when ads are allowed to run during the video
+    # @see https://developers.google.com/youtube/partner/docs/v1/videoAdvertisingOptions
+    class VideoAdvertisingOptions < Base
+      include Actions::Get
+      def initialize(options = {})
+        @video_id = options[:video_id]
+        @auth = options[:auth]
+        do_get() {|data| @data = data}
+      end
+
+      # update the advertising options
+      def update(attributes = {})
+
+        body = @data.deep_merge(attributes)
+        do_update(body: body) do |data|
+          @data = data
+        end
+
+        true
+      end
+
+    private
+
+      def get_params
+        super.tap do |params|
+          params[:path] = "/youtube/partner/v1/videoAdvertisingOptions/#{@video_id}"
+          params[:params] = {onBehalfOfContentOwner: @auth.owner_name}
+        end
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to update advertising options
+      # @see https://developers.google.com/youtube/partner/docs/v1/videoAdvertisingOptions/update
+      def update_params
+        super.tap do |params|
+          params[:path] = "/youtube/partner/v1/videoAdvertisingOptions/#{@video_id}/"
+          params[:params] = {onBehalfOfContentOwner: @auth.owner_name}
+          params[:expected_response] = Net::HTTPOK
+        end
+      end
+
+    end
+  end
+end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.11.1'
+  VERSION = '0.11.2'
 end


### PR DESCRIPTION
Added some classes and methods needed to control monetization settings for an uploaded video.  The idea is to do as follows in Accounts:

```
asset = content_owner.create_asset type: 'web'
ownership = Yt::Ownership.new asset_id: asset.id, auth: content_owner
ownership.update kind: "youtubePartner#rightsOwnership", general: [{ratio: 100.0, owner: content_owner.owner_name, type: "exclude", territories: []}]
video = VaultVideo.find_by_slug 'famOnt'
policy = {rules: [{action: "monetize"}]}
content_owner.claims.insert assetId: asset.id, videoId: video.youtube_id, policy: policy, contentType: "audiovisual"
```
