### PR TITLE
Add asset#update via patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.11.3 - 2014-08-21
+
+* [FEATURE] Add `update` method to Asset model
+
 ## 0.11.2 - 2014-08-20
 
 * [FEATURE] Add AdvertisingOptionsSet with `update` to change the advertising settings of a video

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.11.2'
+    gem 'yt', '~> 0.11.3'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)
@@ -464,6 +464,7 @@ Yt::Asset
 Use [Yt::Asset](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models/Asset) to:
 
 * read the ownership of an asset
+* update the attributes of an asset
 
 ```ruby
 
@@ -473,6 +474,8 @@ asset.ownership #=> #<Yt::Models::Ownership @general=...>
 asset.ownership.obtain! #=> true
 asset.general_owners.first.owner #=> 'CMSname'
 asset.general_owners.first.everywhere? #=> true
+
+asset.update metadata_mine: {notes: 'Some notes'} #=> true
 ```
 
 *The methods above require to be authenticated as the video’s content owner (see below).*

--- a/lib/yt/models/asset.rb
+++ b/lib/yt/models/asset.rb
@@ -13,6 +13,12 @@ module Yt
         @auth = options[:auth]
       end
 
+      def update(attributes = {})
+        underscore_keys! attributes
+        do_patch body: attributes
+        true
+      end
+
       # @!attribute [r] ownership
       #   @return [Yt::Models::Ownership] the asset’s ownership.
       has_one :ownership
@@ -30,7 +36,7 @@ module Yt
       # @return [Boolean] whether the asset is inactive.
       # def delete
       #   body = {id: id, status: :inactive}
-      #   do_update(body: body) {|data| @data = data}
+      #   do_patch(body: body) {|data| @data = data}
       #   inactive?
       # end
 
@@ -83,18 +89,15 @@ module Yt
 
     private
 
-      # @see https://developers.google.com/youtube/partner/docs/v1/assets/update
-      # @note Despite what the documentation says, YouTube API never returns
-      #   the status of an asset, so it’s impossible to update, although the
-      #   documentation says this should be the case. If YouTube ever fixes
-      #   the API, then the following code can be uncommented.
-      # def update_params
-      #   super.tap do |params|
-      #     params[:expected_response] = Net::HTTPOK
-      #     params[:path] = "/youtube/partner/v1/assets/#{id}"
-      #     params[:params] = {on_behalf_of_content_owner: @auth.owner_name}
-      #   end
-      # end
+      # @see https://developers.google.com/youtube/partner/docs/v1/assets/patch
+      def patch_params
+        super.tap do |params|
+          params[:expected_response] = Net::HTTPOK
+          params[:path] = "/youtube/partner/v1/assets/#{@id}"
+          params[:params] = {on_behalf_of_content_owner: @auth.owner_name}
+        end
+      end
+
     end
   end
 end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.11.2'
+  VERSION = '0.11.3'
 end

--- a/spec/requests/as_content_owner/asset_spec.rb
+++ b/spec/requests/as_content_owner/asset_spec.rb
@@ -6,7 +6,15 @@ describe Yt::Asset, :partner do
     let(:asset) { Yt::Asset.new id: asset_id, auth: $content_owner }
     describe 'given an asset administered by the content owner' do
       let(:asset_id) { ENV['YT_TEST_PARTNER_ASSET_ID'] }
-      it { expect(asset.ownership).to be_a Yt::Ownership }
+
+      specify 'the ownership can be obtained' do
+        expect(asset.ownership).to be_a Yt::Ownership
+      end
+
+      describe 'the asset can be updated' do
+        let(:attrs) { {metadata_mine: {notes: 'Yt notes'}} }
+        it { expect(asset.update attrs).to be true }
+      end
     end
   end
 end


### PR DESCRIPTION
Allows for updating metadata fields of as asset

``` ruby
asset = Yt::Asset.new(id: 'A435476563920238', auth: content_owner)
asset.update metadata_mine: { customId: '7cj0MhObCQk' } #=> true
```
