### PR TITLE
Add AS::Notifications to YouTube requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,6 +511,25 @@ ad_options.update ad_formats: %w(standard_instream long) #=> true
 
 *The methods above require to be authenticated as the video’s content owner (see below).*
 
+Instrumentation
+===============
+
+Yt leverages [Active Support Instrumentation](http://edgeguides.rubyonrails.org/active_support_instrumentation.html) to provide a hook which developers can use to be notified when HTTP requests to YouTube are made.  This hook may be used to track the number of requests over time, monitor quota usage, provide an audit trail, or track how long a specific request takes to complete.
+
+Subscribe to the `request.yt` notification within your application:
+
+```ruby
+ActiveSupport::Notifications.subscribe 'request.yt' do |*args|
+  event = ActiveSupport::Notifications::Event.new(*args)
+
+  event.payload[:request_uri] #=> #<URI::HTTPS URL:https://www.googleapis.com/youtube/v3/channels?id=UCxO1tY8h1AhOz0T4ENwmpow&part=snippet>
+  event.payload[:method] #=> :get
+  event.payload[:response] #=> #<Net::HTTPOK 200 OK readbody=true>
+
+  event.end #=> 2014-08-22 16:57:17 -0700
+  event.duration #=> 141.867 (ms)
+end
+```
 
 Configuring your app
 ====================

--- a/lib/yt/models/request.rb
+++ b/lib/yt/models/request.rb
@@ -51,8 +51,10 @@ module Yt
     private
 
       def response
-        @response ||= Net::HTTP.start(*net_http_options) do |http|
-          http.request http_request
+        @response ||= ActiveSupport::Notifications.instrument 'request.yt' do |payload|
+          payload[:method] = @method
+          payload[:request_uri] = uri
+          payload[:response] = Net::HTTP.start(*net_http_options) { |http| http.request http_request }
         end
       rescue OpenSSL::SSL::SSLError, Errno::ETIMEDOUT, Errno::ENETUNREACH, Errno::ECONNRESET => e
         @response ||= e

--- a/lib/yt/models/request.rb
+++ b/lib/yt/models/request.rb
@@ -51,13 +51,19 @@ module Yt
     private
 
       def response
-        @response ||= ActiveSupport::Notifications.instrument 'request.yt' do |payload|
-          payload[:method] = @method
-          payload[:request_uri] = uri
-          payload[:response] = Net::HTTP.start(*net_http_options) { |http| http.request http_request }
-        end
+        @response ||= send_http_request
       rescue OpenSSL::SSL::SSLError, Errno::ETIMEDOUT, Errno::ENETUNREACH, Errno::ECONNRESET => e
         @response ||= e
+      end
+
+      def send_http_request
+        ActiveSupport::Notifications.instrument 'request.yt' do |payload|
+          payload[:method] = @method
+          payload[:request_uri] = uri
+          payload[:response] = Net::HTTP.start(*net_http_options) do |http|
+            http.request http_request
+          end
+        end
       end
 
       def http_request


### PR DESCRIPTION
Opening this PR for discussion.

ActiveSupport::Notifications, by convention, should be namespaced right-to-left, so I've named this `request.yt` (feel free to change this though).

Could be useful for:
- Quota / Request analysis
- Time spent making YouTube requests
- Audit Trails
