### PR TITLE
Extract AS::Notification in a separate method

### DIFF
--- a/lib/yt/models/request.rb
+++ b/lib/yt/models/request.rb
@@ -51,13 +51,19 @@ module Yt
     private
 
       def response
-        @response ||= ActiveSupport::Notifications.instrument 'request.yt' do |payload|
-          payload[:method] = @method
-          payload[:request_uri] = uri
-          payload[:response] = Net::HTTP.start(*net_http_options) { |http| http.request http_request }
-        end
+        @response ||= send_http_request
       rescue OpenSSL::SSL::SSLError, Errno::ETIMEDOUT, Errno::ENETUNREACH, Errno::ECONNRESET => e
         @response ||= e
+      end
+
+      def send_http_request
+        ActiveSupport::Notifications.instrument 'request.yt' do |payload|
+          payload[:method] = @method
+          payload[:request_uri] = uri
+          payload[:response] = Net::HTTP.start(*net_http_options) do |http|
+            http.request http_request
+          end
+        end
       end
 
       def http_request


### PR DESCRIPTION
I like short methods and short lines of code.
@stavro how about extracting `instrument` into its own `send_http_request` method?

The rest looks great, I just need to run the test suite.
I think with this addition we might even get rid of that `p as_curl`!
