### PR TITLE
Route videos collection to Videos#list for specified parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.11.4 - 2014-08-27
+
+* [ENHANCEMENT] Add Video search even by id, chart or rating
+* [FEATURE] Add `ActiveSupport::Notification` to inspect HTTP requests
+
 ## 0.11.3 - 2014-08-21
 
 * [FEATURE] Add `update` method to Asset model

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.11.3'
+    gem 'yt', '~> 0.11.4'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)
@@ -74,6 +74,7 @@ account.videos.first #=> #<Yt::Models::Video @id=...>
 
 account.upload_video 'my_video.mp4', title: 'My new video', privacy_status: 'private'
 account.upload_video 'http://example.com/remote.m4v', title: 'My other video', tags: ['music']
+
 ```
 
 *The methods above require to be authenticated as a YouTube account (see below).*
@@ -422,6 +423,8 @@ Use [Yt::Collections::Videos](http://rubydoc.info/github/Fullscreen/yt/master/Yt
 videos = Yt::Collections::Videos.new
 videos.where(order: 'viewCount').first.title #=>  "PSY - GANGNAM STYLE"
 videos.where(q: 'Fullscreen CreatorPlatform', safe_search: 'none').size #=> 324
+videos.where(chart: 'mostPopular', video_category_id: 44).first.title #=> "SINISTER - Trailer"
+videos.where(id: 'MESycYJytkU,invalid').map(&:title) #=> ["Fullscreen Creator Platform"]
 ```
 
 *The methods above do not require authentication.*

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -41,7 +41,7 @@ module Yt
       end
 
       # @private
-      # @todo: This is the only place outside of base.rb where @where_params
+      # @todo: This is one of two places outside of base.rb where @where_params
       #   is accessed; it should be replaced with a filter on params instead.
       def claims_path
         @where_params ||= {}

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -21,7 +21,7 @@ module Yt
       def list_params
         super.tap do |params|
           params[:params] = videos_params
-          params[:path] = '/youtube/v3/search'
+          params[:path] = videos_path
         end
       end
 
@@ -49,6 +49,19 @@ module Yt
           params[:published_before] = @published_before if @published_before
           params.merge! @parent.videos_params if @parent
           apply_where_params! params
+        end
+      end
+
+      # @private
+      # @todo: This is one of two places outside of base.rb where @where_params
+      #   is accessed; it should be replaced with a filter on params instead.
+      # @see https://developers.google.com/youtube/v3/docs/videos/list
+      def videos_path
+        @where_params ||= {}
+        if @parent.nil? && (@where_params.keys & [:id, :chart]).any?
+          '/youtube/v3/videos'
+        else
+          '/youtube/v3/search'
         end
       end
     end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.11.3'
+  VERSION = '0.11.4'
 end

--- a/spec/requests/as_account/account_spec.rb
+++ b/spec/requests/as_account/account_spec.rb
@@ -14,7 +14,7 @@ describe Yt::Account, :device_app do
   describe '.videos' do
     let(:video) { $account.videos.where(order: 'viewCount').first }
 
-    specify 'returns the account’s videos with its tags' do
+    specify 'returns the videos uploaded by the account with their tags' do
       expect(video).to be_a Yt::Video
       expect(video.tags).not_to be_empty
     end
@@ -31,6 +31,16 @@ describe Yt::Account, :device_app do
         let(:query) { '--not-a-matching-query-string--' }
         it { expect(count).to be_zero }
       end
+    end
+
+    describe 'ignores filters by ID (all the videos uploaded by the account are returned)' do
+      let(:other_video) { $account.videos.where(order: 'viewCount', id: 'invalid').first }
+      it { expect(other_video.id).to eq video.id }
+    end
+
+    describe 'ignores filters by chart (all the videos uploaded by the account are returned)' do
+      let(:other_video) { $account.videos.where(order: 'viewCount', chart: 'invalid').first }
+      it { expect(other_video.id).to eq video.id }
     end
   end
 

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -42,6 +42,14 @@ describe Yt::Channel, :device_app do
       it { expect(channel.unsubscribe!).to be_truthy }
     end
 
+    describe 'filtering by ID is ignored when listing videos' do
+      it { expect(channel.videos.where(id: 'invalid').first).to be_a Yt::Video }
+    end
+
+    describe 'filtering by chart is ignored when listing videos' do
+      it { expect(channel.videos.where(chart: 'invalid').first).to be_a Yt::Video }
+    end
+
     # @note: these tests are slow because they go through multiple pages of
     #   results and do so to test that we can overcome YouTube’s limitation of
     #   only returning the first 500 results for each query.

--- a/spec/requests/as_server_app/videos_spec.rb
+++ b/spec/requests/as_server_app/videos_spec.rb
@@ -12,4 +12,12 @@ describe Yt::Collections::Videos, :server_app do
   specify 'with a query term, only returns some YouTube videos' do
     expect(videos.where(q: 'Fullscreen CreatorPlatform', video_duration: :long).size).to be < 100_000
   end
+
+  specify 'with a list of video IDs, only returns the videos matching those IDs' do
+    expect(videos.where(id: 'MESycYJytkU,invalid').size).to be 1
+  end
+
+  specify 'with a chart parameter, only returns videos of that chart', :ruby2 do
+    expect(videos.where(chart: 'mostPopular').size).to be 200
+  end
 end


### PR DESCRIPTION
Adds support for Videos#list endpoint:

``` ruby
videos = Yt::Collections::Videos.new

# Obtain a collection of videos in one API call
videos.where(id: 'cuKWgvkxvBk,a6QHzIJO5a8').size #=> 2

# Most popular videos in the People & Blogs category
videos.where(chart: 'mostPopular', video_category_id: 22).first #<Yt::Models::Video ... >

# Most popular videos in a particular region
videos.where(chart: 'mostPopular', region_code: 'US').first #<Yt::Models::Video ... >

# Videos an account has liked or disliked
account = Yt::Account.new access_token: 'ya29.abcdefg'
videos = Yt::Collections::Videos.new auth: account

videos.where(my_rating: 'like').size #=> 41
videos.where(my_rating: 'dislike').size #=> 6
```
