### PR TITLE
Videos#list id fix

### DIFF
--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -76,8 +76,12 @@ module Yt
       # @return [Array<Yt::Models::Tag>] the list of keyword tags associated
       #   with the video.
       def tags
-        @snippet = nil unless snippet.includes_tags
-        snippet.tags
+        if @auth
+          @snippet = nil unless snippet.includes_tags
+          snippet.tags
+        else
+          []
+        end
       end
 
       # Deletes the video.


### PR DESCRIPTION
- [x] Only Videos#search should expected the nested `videoId` parameter

One minor change:

Tags are **only** visible under the following conditions:
1. You are using Videos#list, not Videos#search
2. You are using an authorized request, not a public one

If both of these conditions are met, you will receive the tags **if** you are authorized to see them (either your channel, or that channel's content owner).
