### PR TITLE
Fix video list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.11.5 - 2014-08-27
+
+* [BUGFIX] Make videos.where(id: 'MESycYJytkU').first.id return 'MESycYJytkU'
+
 ## 0.11.4 - 2014-08-27
 
 * [ENHANCEMENT] Add Video search even by id, chart or rating

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.11.4'
+    gem 'yt', '~> 0.11.5'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -76,7 +76,9 @@ module Yt
       # @return [Array<Yt::Models::Tag>] the list of keyword tags associated
       #   with the video.
       def tags
-        @snippet = nil unless snippet.includes_tags
+        unless snippet.tags.any? || snippet.includes_tags || @auth.nil?
+          @snippet = nil
+        end
         snippet.tags
       end
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.11.4'
+  VERSION = '0.11.5'
 end

--- a/spec/requests/as_server_app/videos_spec.rb
+++ b/spec/requests/as_server_app/videos_spec.rb
@@ -13,8 +13,12 @@ describe Yt::Collections::Videos, :server_app do
     expect(videos.where(q: 'Fullscreen CreatorPlatform', video_duration: :long).size).to be < 100_000
   end
 
-  specify 'with a list of video IDs, only returns the videos matching those IDs' do
-    expect(videos.where(id: 'MESycYJytkU,invalid').size).to be 1
+  context 'with a list of video IDs, only returns the videos matching those IDs' do
+    let(:video_id) { 'MESycYJytkU' }
+    let(:videos_by_id) { videos.where id: "#{video_id},invalid" }
+
+    it { expect(videos_by_id.size).to be 1 }
+    it { expect(videos_by_id.first.id).to eq video_id }
   end
 
   specify 'with a chart parameter, only returns videos of that chart', :ruby2 do


### PR DESCRIPTION
Closes #82 – The logic of tags in #82 was not right; we used to specify `includes_tags: false` when we were **sure** the response did not contain tags, but with the new endpoint this has changed.

Simply, when we ask for `video.tags` and the snippet _already has tags_ (because they were already returned by Videos#list), we return them, rather than erasing the `@snippet` variable.

On the other hand, when the snippet _does not have tags_ but we don’t have an authentication, it's useless to make an extra Video#show call, because without an authorizations, tags won't be returned anyways.
