### PR TITLE
Add support for Collections::Videos.includes

### DIFF
--- a/lib/yt/actions/base.rb
+++ b/lib/yt/actions/base.rb
@@ -10,6 +10,7 @@ module Yt
       # invoke transform_keys!{|key| key.to_s.underscore.to_sym}
       def underscore_keys!(hash)
         hash.dup.each_key{|key| hash[underscore key] = hash.delete key}
+        hash
       end
 
       def underscore(value)

--- a/lib/yt/collections/base.rb
+++ b/lib/yt/collections/base.rb
@@ -13,6 +13,8 @@ module Yt
       def initialize(options = {})
         @parent = options[:parent]
         @auth = options[:auth]
+        @where_params = {}
+        @included_parts = []
       end
 
       def self.of(parent)
@@ -41,10 +43,17 @@ module Yt
         end
       end
 
+      def includes(*parts)
+        self.tap do
+          @items = []
+          @included_parts = parts
+        end
+      end
+
     private
 
       def apply_where_params!(params = {})
-        params.merge!(@where_params ||= {})
+        params.merge! @where_params
       end
     end
   end

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -44,7 +44,6 @@ module Yt
       # @todo: This is one of two places outside of base.rb where @where_params
       #   is accessed; it should be replaced with a filter on params instead.
       def claims_path
-        @where_params ||= {}
         if @where_params.empty? || @where_params.key?(:id)
           '/youtube/partner/v1/claims'
         else

--- a/lib/yt/collections/device_flows.rb
+++ b/lib/yt/collections/device_flows.rb
@@ -8,7 +8,7 @@ module Yt
 
     private
 
-      # This overrides the parent mehthod defined in Authentications
+      # This overrides the parent method defined in Authentications
       def attributes_for_new_item(data)
         {data: data}
       end

--- a/lib/yt/models/resource.rb
+++ b/lib/yt/models/resource.rb
@@ -22,6 +22,8 @@ module Yt
         @auth = options[:auth]
         @snippet = Snippet.new(data: options[:snippet]) if options[:snippet]
         @status = Status.new(data: options[:status]) if options[:status]
+        @statistics_set = StatisticsSet.new(data: options[:statistics]) if options[:statistics]
+        @content_detail = ContentDetail.new(data: options[:content_details]) if options[:content_details]
       end
 
       def kind


### PR DESCRIPTION
Allows for requesting multiple resource parts in a single video request.
### Usage

``` ruby
videos = Yt::Collections::Videos.new.where(id: 'sMeEwjQFGOU,BopDHDQGud8').includes(:statistics, :content_details, :status).each do |video|
  puts video.title
  puts video.view_count
  puts video.duration
  puts video.has_public_stats_viewable?
end
```
### Output

```
Successful YT get "https://www.googleapis.com/youtube/v3/videos?id=sMeEwjQFGOU%2CBopDHDQGud8&maxResults=50&order=date&part=statistics%2CcontentDetails%2Cstatus%2Csnippet&type=video&key=" in 241.749ms
MAN OF STEEL - Official Trailer #3 (With Henry Cavill Intro) (2013) [HD]
262984
196
true
Human Water Catapult - 55 Foot Launch! In 4k
750178
182
true
```
