### PR TITLE
Pass statistics and content details to Video#new

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.12.2 - 2014-09-09
+
+* [ENHANCEMENT] Accept `part` in the `where` clause of Videos, so statistics and content details can be eagerly loaded.
+
 ## 0.12.1 - 2014-09-04
 
 * [ENHANCEMENT] Add `position` option to add_video (to specify where in a playlist to add a video)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.12.1'
+    gem 'yt', '~> 0.12.2'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -13,8 +13,15 @@ module Yt
 
       def attributes_for_new_item(data)
         id = use_list_endpoint? ? data['id'] : data['id']['videoId']
-        snippet = data.fetch('snippet', {}).merge includes_tags: false
-        {id: id, snippet: snippet, auth: @auth}
+        snippet = data['snippet'].merge includes_tags: false if data['snippet']
+        {}.tap do |attributes|
+          attributes[:id] = id
+          attributes[:snippet] = snippet
+          attributes[:status] = data['status']
+          attributes[:content_details] = data['contentDetails']
+          attributes[:statistics] = data['statistics']
+          attributes[:auth] = @auth
+        end
       end
 
       # @return [Hash] the parameters to submit to YouTube to list videos.

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -67,6 +67,18 @@ module Yt
       delegate :view_count, :like_count, :dislike_count, :favorite_count,
         :comment_count, to: :statistics_set
 
+      # Override Resource's new to set statistics and content details as well
+      # if the response includes them
+      def initialize(options = {})
+        super options
+        if options[:statistics]
+          @statistics_set = StatisticsSet.new data: options[:statistics]
+        end
+        if options[:content_details]
+          @content_detail = ContentDetail.new data: options[:content_details]
+        end
+      end
+
       # Returns the list of keyword tags associated with the video.
       # Since YouTube API only returns tags on Videos#list, the memoized
       # @snippet is erased if the video was instantiated through Video#search

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.12.1'
+  VERSION = '0.12.2'
 end

--- a/spec/models/video_spec.rb
+++ b/spec/models/video_spec.rb
@@ -11,6 +11,20 @@ describe Yt::Video do
     end
   end
 
+  describe '#statistics_set' do
+    context 'given fetching a video returns statistics' do
+      let(:attrs) { {statistics: {"viewCount"=>"202"}} }
+      it { expect(video.statistics_set).to be_a Yt::StatisticsSet }
+    end
+  end
+
+  describe '#content_details' do
+    context 'given fetching a video returns content details' do
+      let(:attrs) { {content_details: {"definition"=>"hd"}} }
+      it { expect(video.content_detail).to be_a Yt::ContentDetail }
+    end
+  end
+
   describe '#update' do
     let(:attrs) { {id: 'MESycYJytkU', snippet: {'title'=>'old'}} }
     before { expect(video).to receive(:do_update).and_yield 'snippet'=>{'title'=>'new'} }

--- a/spec/requests/as_server_app/videos_spec.rb
+++ b/spec/requests/as_server_app/videos_spec.rb
@@ -24,4 +24,17 @@ describe Yt::Collections::Videos, :server_app do
   specify 'with a chart parameter, only returns videos of that chart', :ruby2 do
     expect(videos.where(chart: 'mostPopular').size).to be 200
   end
+
+  context 'with a list of parts' do
+    let(:video_id) { 'MESycYJytkU' }
+    let(:part) { 'statistics,contentDetails' }
+    let(:video) { videos.where(id: 'MESycYJytkU', part: part).first }
+
+    specify 'load ONLY the specified parts of the videos' do
+      expect(video.instance_variable_defined? :@snippet).to be false
+      expect(video.instance_variable_defined? :@status).to be false
+      expect(video.instance_variable_defined? :@statistics_set).to be true
+      expect(video.instance_variable_defined? :@content_detail).to be true
+    end
+  end
 end


### PR DESCRIPTION
If a user specifies .where(part: 'statistics') when listing videos,
then YouTube will return the "statistics" part and the Video object
will be initialized with that data. Same for content details.

This **overrides the default behavior** of including status and snippet,
so if those parts are still required, the request should be:

```
.where(part: 'statistics,snippet,status,contentDetails')
```

---

This partially solves the issue tackled by #84 adding missing specs and moving code from "Resources" to "Videos", since not all resources have statistics and content details (e.g., playlists and playlist items don't).

I think the general issue raised by #84 is still relevant (to add an `.include` method, rather than passing the parts to `.where`), but for the sake of unblocking that issue, I suggest for this PR to be merged.

Note that extending the behavior of this PR from Videos to Channels can be done by… duplicating the code :scream: – not a big deal because these methods are being rewritten in a different branch :blush:
