### PR TITLE
Move create_playlist from Channel to Account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,18 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-## 0.12.3 - unreleased
+## 0.13.0 - 2014-09-11
 
+**How to upgrade**
+
+If your code never calls the `create_playlist` on a Channel object, then you
+are good to go.
+
+If it does, then replace your calls to `channel.create_playlist` with
+`account.create_playlist`, that is, call `create_playlist` on the channel’s
+account instead.
+
+* [ENHANCEMENT] Remove `create_playlist` from Channel (still exists on Account)
 * [ENHANCEMENT] Accept `category_id` in `upload_video`.
 
 ## 0.12.2 - 2014-09-09

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.12.2'
+    gem 'yt', '~> 0.13.0'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)
@@ -60,6 +60,7 @@ Use [Yt::Account](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models/Acco
 * read the attributes of the account
 * access the channel managed by the account
 * access the videos uploaded by the account
+* create playlist
 * upload a video
 * list the channels subscribed to an account
 
@@ -75,6 +76,8 @@ account.videos.first #=> #<Yt::Models::Video @id=...>
 
 account.upload_video 'my_video.mp4', title: 'My new video', privacy_status: 'private', category_id: 17
 account.upload_video 'http://example.com/remote.m4v', title: 'My other video', tags: ['music']
+
+account.create_playlist title: 'New playlist', privacy_status: 'unlisted' #=> true
 
 account.subscribers.count #=> 2
 account.subscribers.first #=> #<Yt::Models::Channel @id=...>
@@ -141,7 +144,7 @@ Use [Yt::Channel](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models/Chan
 * access the playlists of a channel
 * access the channels that the channel is subscribed to
 * subscribe to and unsubscribe from a channel
-* create and delete playlists from a channel
+* delete playlists from a channel
 * retrieve the daily earnings, views, comments, likes, dislikes, shares and impressions of a channel
 * retrieve the viewer percentage of a channel by gender and age group
 
@@ -188,7 +191,6 @@ channel.subscribe #=> true
 account = Yt::Account.new access_token: 'ya29.1.ABCDEFGHIJ'
 channel = Yt::Channel.new id: 'UCxO1tY8h1AhOz0T4ENwmpow', auth: account
 
-channel.create_playlist title: 'New playlist' #=> true
 channel.delete_playlists title: 'New playlist' #=> [true]
 
 channel.views since: 7.days.ago #=> {Wed, 28 May 2014 => 12.0, Thu, 29 May 2014 => 3.0, …}

--- a/lib/yt/models/account.rb
+++ b/lib/yt/models/account.rb
@@ -9,7 +9,7 @@ module Yt
       # @!attribute [r] channel
       #   @return [Yt::Models::Channel] the account’s channel.
       has_one :channel
-      delegate :playlists, :create_playlist, :delete_playlists,
+      delegate :playlists, :delete_playlists,
         :subscribed_channels, to: :channel
 
       # @!attribute [r] user_info
@@ -42,6 +42,10 @@ module Yt
       #     by the account.
       has_many :content_owners
 
+      # @!attribute [r] playlists
+      #   @return [Yt::Collections::Playlists] the account’s playlists.
+      has_many :playlists
+
       # Uploads a video
       # @param [String] path_or_url the video to upload. Can either be the
       #   path of a local file or the URL of a remote file.
@@ -55,6 +59,10 @@ module Yt
         file = open path_or_url, 'rb'
         session = resumable_sessions.insert file.size, params
         session.upload_video file
+      end
+
+      def create_playlist(params = {})
+        playlists.insert params
       end
 
       # @private

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -131,10 +131,6 @@ module Yt
         end
       end
 
-      def create_playlist(params = {})
-        playlists.insert params
-      end
-
       def delete_playlists(attrs = {})
         playlists.delete_all attrs
       end

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.12.2'
+  VERSION = '0.13.0'
 end

--- a/spec/requests/as_account/account_spec.rb
+++ b/spec/requests/as_account/account_spec.rb
@@ -3,6 +3,13 @@ require 'spec_helper'
 require 'yt/models/account'
 
 describe Yt::Account, :device_app do
+  describe 'can create playlists' do
+    let(:params) { {title: 'Test Yt playlist', privacy_status: 'unlisted'} }
+    before { @playlist = $account.create_playlist params }
+    it { expect(@playlist).to be_a Yt::Playlist }
+    after { @playlist.delete }
+  end
+
   describe '.channel' do
     it { expect($account.channel).to be_a Yt::Channel }
   end

--- a/spec/requests/as_account/channel_spec.rb
+++ b/spec/requests/as_account/channel_spec.rb
@@ -23,7 +23,6 @@ describe Yt::Channel, :device_app do
 
     it { expect(channel.videos.first).to be_a Yt::Video }
     it { expect(channel.playlists.first).to be_a Yt::Playlist }
-    it { expect{channel.create_playlist}.to raise_error Yt::Errors::RequestError }
     it { expect{channel.delete_playlists}.to raise_error Yt::Errors::RequestError }
 
     specify 'with a public list of subscriptions' do
@@ -105,15 +104,9 @@ describe Yt::Channel, :device_app do
       expect(channel.subscriptions.size).to be
     end
 
-    describe 'playlists can be added' do
-      after { channel.delete_playlists params }
-      it { expect(channel.create_playlist params).to be_a Yt::Playlist }
-      it { expect{channel.create_playlist params}.to change{channel.playlists.count}.by(1) }
-    end
-
     describe 'playlists can be deleted' do
       let(:title) { "Yt Test Delete All Playlists #{rand}" }
-      before { channel.create_playlist params }
+      before { $account.create_playlist params }
 
       it { expect(channel.delete_playlists title: %r{#{params[:title]}}).to eq [true] }
       it { expect(channel.delete_playlists params).to eq [true] }


### PR DESCRIPTION
According to YouTube API documentation, an account can create a
playlist without passing any information about the channel that
the playlist will belong to.

The playlist will always belong to the account’s channel, so
it is correct to have `account.create_playlist`, rather than
`channel.create_playlist`.
