### PR TITLE
don't add publishedAt offset to list endpoint. Fixes #89

### DIFF
--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -34,7 +34,9 @@ module Yt
       end
 
       def next_page
-        super.tap{|items| add_offset_to(items) if @page_token.nil?}
+        super.tap do |items|
+          add_offset_to(items) if !use_list_endpoint? && @page_token.nil?
+        end
       end
 
       # According to http://stackoverflow.com/a/23256768 YouTube does not


### PR DESCRIPTION
before: 

``` ruby
Yt::Collections::Videos.new.where(id: "xKXEr0dZwM4,1OGDzm9YylY", part: 'statistics').map { |v| v.view_count }
 => Yt::Errors::RequestError
# "response_body":{"error":{"errors":[{"domain":"youtube.part","reason":"unknownPart","message":"statistics","locationType":"parameter","location":"part"}],"code":400,"message":"statistics"}}}
```

after:

``` ruby
Yt::Collections::Videos.new.where(id: "xKXEr0dZwM4,1OGDzm9YylY", part: 'statistics').map { |v| v.view_count }
 => [28956, 601505]
```
