### PR TITLE
Allow for insertion of claims with custom policy rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.13.4 - 2014-10-01
+
+* [ENHANCEMENT] Accept `policy` (with custom set of rules) in `content_owner.create_claim`
+
 ## 0.13.3 - 2014-10-01
 
 * [BUGFIX] Rescue OpenSSL::SSL::SSLErrorWaitReadable raised by YouTube servers.

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -9,7 +9,7 @@ module Yt
     class Claims < Base
       def insert(attributes = {})
         underscore_keys! attributes
-        body = attributes.slice :asset_id, :video_id, :content_type
+        body = attributes.slice :asset_id, :video_id, :content_type, :policy
         body[:policy] = {id: attributes[:policy_id]} if attributes[:policy_id]
         params = {on_behalf_of_content_owner: @auth.owner_name}
         do_insert(params: params, body: body)


### PR DESCRIPTION
This should be a valid operation with `yt`: 

``` ruby
content_owner.claims.insert(
  asset_id: 'A1234',
  video_id: 'abcd',
  content_type: 'audiovisual',
  policy: {
    rules: [
      {
        action: 'block'
      }
    ]
  }
)
```

However, the `yt` gem currently only looks for a `policy_id`.

This PR allows for the submission of custom policy rules.
