### PR TITLE
Convenience method for releasing ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.13.2 - 2014-10-01
+
+* [FEATURE] Add `release!` to Ownership.
+
 ## 0.13.1 - 2014-09-18
 
 * [BUGFIX] Make list videos by id work for exactly 50 ids.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.13.1'
+    gem 'yt', '~> 0.13.2'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/models/ownership.rb
+++ b/lib/yt/models/ownership.rb
@@ -24,6 +24,11 @@ module Yt
         update general: [{ratio: 100, owner: @auth.owner_name, type: :exclude}]
       end
 
+      # Releases 100% of the general ownership of the asset from @auth.
+      def release!
+        update general: [{ratio: 0, owner: @auth.owner_name, type: :exclude}]
+      end
+
       # @return [Array<RightOwner>] a list that identifies the owners of an
       #   asset and the territories where each owner has ownership.
       #   General  asset ownership is used for all types of assets and is the

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.13.1'
+  VERSION = '0.13.2'
 end

--- a/spec/requests/as_content_owner/match_policy_spec.rb
+++ b/spec/requests/as_content_owner/match_policy_spec.rb
@@ -5,6 +5,7 @@ describe Yt::MatchPolicy, :partner do
   subject(:match_policy) { Yt::MatchPolicy.new asset_id: asset_id, auth: $content_owner }
 
   context 'given an asset managed by the authenticated Content Owner' do
+    before { Yt::Ownership.new(asset_id: asset_id, auth: $content_owner).obtain! }
     let(:asset_id) { ENV['YT_TEST_PARTNER_ASSET_ID'] }
 
     describe 'the asset match policy can be updated' do

--- a/spec/requests/as_content_owner/ownership_spec.rb
+++ b/spec/requests/as_content_owner/ownership_spec.rb
@@ -15,5 +15,9 @@ describe Yt::Ownership, :partner do
     describe 'the complete ownership can be obtained' do
       it { expect(ownership.obtain!).to be true }
     end
+
+    describe 'the complete ownership can be released' do
+      it { expect(ownership.release!).to be true }
+    end
   end
 end


### PR DESCRIPTION
Convenience method for releasing ownership.  Counterpart of `obtain!`

``` ruby
Yt::Asset.new(id: '', auth: @auth).ownership.release!
```
