### PR TITLE
Rescue OpenSSL::SSL::SSLErrorWaitReadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.13.3 - 2014-10-01
+
+* [BUGFIX] Rescue OpenSSL::SSL::SSLErrorWaitReadable raised by YouTube servers.
+
 ## 0.13.2 - 2014-10-01
 
 * [FEATURE] Add `release!` to Ownership.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ To install on your system, run
 
 To use inside a bundled Ruby project, add this line to the Gemfile:
 
-    gem 'yt', '~> 0.13.2'
+    gem 'yt', '~> 0.13.3'
 
 Since the gem follows [Semantic Versioning](http://semver.org),
 indicating the full version in your Gemfile (~> *major*.*minor*.*patch*)

--- a/lib/yt/request.rb
+++ b/lib/yt/request.rb
@@ -202,6 +202,7 @@ module Yt
     def server_errors
       [
         OpenSSL::SSL::SSLError,
+        OpenSSL::SSL::SSLErrorWaitReadable,
         Errno::ETIMEDOUT,
         Errno::ENETUNREACH,
         Errno::ECONNRESET,

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.13.2'
+  VERSION = '0.13.3'
 end

--- a/spec/models/request_spec.rb
+++ b/spec/models/request_spec.rb
@@ -116,6 +116,27 @@ describe Yt::Request do
           it { expect{request.run}.not_to fail }
         end
       end
+
+      # NOTE: This test is just a reflection of YouTube irrational behavior of
+      # being unavailable once in a while, and therefore causing Net::HTTP to
+      # fail, although retrying after some seconds works.
+      context 'an OpenSSL::SSL::SSLErrorWaitReadable' do
+        let(:http_error) { OpenSSL::SSL::SSLErrorWaitReadable.new }
+
+        context 'every time' do
+          before { expect(Net::HTTP).to receive(:start).at_least(:once).and_raise http_error }
+
+          it { expect{request.run}.to fail }
+        end
+
+        context 'but works the second time' do
+          before { expect(Net::HTTP).to receive(:start).at_least(:once).and_return retry_response }
+          before { allow(retry_response).to receive(:body) }
+          let(:retry_response) { Net::HTTPOK.new nil, nil, nil }
+
+          it { expect{request.run}.not_to fail }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This is yet another error that YouTube servers raise once in a while
and then can be solved by trying the same request again after a while.

Specifically this occurred once at https://www.honeybadger.io/projects/38575/faults/7853758
