### PR TITLE
Add video.advertising_options_set and .ad_formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.13.5 - 2014-10-06
+
+* [ENHANCEMENT] Add `advertising_options_set` and `ad_formats` to video
+
 ## 0.13.4 - 2014-10-01
 
 * [ENHANCEMENT] Accept `policy` (with custom set of rules) in `content_owner.create_claim`

--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Use [Yt::Video](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models/Video)
 * retrieve the daily earnings, views, comments, likes, dislikes, shares and impressions of a video
 * retrieve the viewer percentage of a video by gender and age group
 * retrieve data about live-streaming videos
+* retrieve the advertising options of a video
 
 ```ruby
 # Videos can be initialized with ID or URL
@@ -345,6 +346,8 @@ video.impressions_on 5.days.ago #=> 157.0
 
 video.viewer_percentages #=> {female: {'18-24' => 12.12, '25-34' => 16.16,…}…}
 video.viewer_percentage(gender: :female) #=> 49.12
+
+video.ad_formats #=> ["standard_instream", "trueview_instream"]
 ```
 
 *The methods above require to be authenticated as the video’s content owner (see below).*
@@ -490,6 +493,7 @@ asset.ownership #=> #<Yt::Models::Ownership @general=...>
 asset.ownership.obtain! #=> true
 asset.general_owners.first.owner #=> 'CMSname'
 asset.general_owners.first.everywhere? #=> true
+asset.ownership.release! #=> true
 
 asset.update metadata_mine: {notes: 'Some notes'} #=> true
 ```

--- a/lib/yt/collections/advertising_options_sets.rb
+++ b/lib/yt/collections/advertising_options_sets.rb
@@ -1,0 +1,34 @@
+require 'yt/collections/resources'
+require 'yt/models/advertising_options_set'
+
+module Yt
+  module Collections
+    # Provides methods to interact with a the advertising options of a YouTube video.
+    #
+    # Resources with advertising options are: {Yt::Models::Video videos}.
+    class AdvertisingOptionsSets < Resources
+
+    private
+
+      def attributes_for_new_item(data)
+        {data: data, video_id: @parent.id, auth: @auth}
+      end
+
+      # @return [Hash] the parameters to submit to YouTube to get video advertising options.
+      # @see https://developers.google.com/youtube/partner/docs/v1/videoAdvertisingOptions/get
+      def list_params
+        super.tap do |params|
+          params[:path] = "/youtube/partner/v1/videoAdvertisingOptions/#{@parent.id}"
+          params[:params] = {on_behalf_of_content_owner: @auth.owner_name}
+        end
+      end
+
+      # @private
+      # @note AdvertisingOptionsSets overwrites +fetch_page+ since it’s a get.
+      def fetch_page(params = {})
+        response = list_request(params).run
+        {items: [response.body], token: nil}
+      end
+    end
+  end
+end

--- a/lib/yt/models/advertising_options_set.rb
+++ b/lib/yt/models/advertising_options_set.rb
@@ -10,12 +10,22 @@ module Yt
       def initialize(options = {})
         @auth = options[:auth]
         @video_id = options[:video_id]
+        @data = options[:data]
       end
 
       def update(attributes = {})
         underscore_keys! attributes
-        do_patch body: attributes
+        do_patch(body: attributes) {|data| @data = data}
         true
+      end
+
+      # Return the list of ad formats that the video is allowed to show.
+      # Valid values for this property are: long, overlay, standard_instream,
+      # third_party, trueview_inslate, or trueview_instream.
+      # @return [Array<String>] the list of ad formats that the video is
+      #   allowed to show.
+      def ad_formats
+        @data['adFormats']
       end
 
     private

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -23,6 +23,9 @@ module Yt
       delegate :duration, :hd?, :stereoscopic?, :captioned?, :licensed?,
         to: :content_detail
 
+      has_one :advertising_options_set
+      delegate :ad_formats, to: :advertising_options_set
+
       # @!attribute [r] rating
       #   @return [Yt::Models::Rating] the video’s rating.
       has_one :rating

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.13.4'
+  VERSION = '0.13.5'
 end

--- a/spec/requests/as_account/video_spec.rb
+++ b/spec/requests/as_account/video_spec.rb
@@ -305,6 +305,7 @@ describe Yt::Video, :device_app do
       expect{video.shares}.not_to raise_error
       expect{video.earnings}.to raise_error Yt::Errors::Unauthorized
       expect{video.impressions}.to raise_error Yt::Errors::Unauthorized
+      expect{video.advertising_options_set}.to raise_error Yt::Errors::Forbidden
 
       expect{video.views_on 3.days.ago}.not_to raise_error
       expect{video.comments_on 3.days.ago}.not_to raise_error

--- a/spec/requests/as_content_owner/ownership_spec.rb
+++ b/spec/requests/as_content_owner/ownership_spec.rb
@@ -13,10 +13,12 @@ describe Yt::Ownership, :partner do
     end
 
     describe 'the complete ownership can be obtained' do
+      before { ownership.release! }
       it { expect(ownership.obtain!).to be true }
     end
 
     describe 'the complete ownership can be released' do
+      after { ownership.obtain! }
       it { expect(ownership.release!).to be true }
     end
   end

--- a/spec/requests/as_content_owner/video_spec.rb
+++ b/spec/requests/as_content_owner/video_spec.rb
@@ -9,6 +9,10 @@ describe Yt::Video, :partner do
     context 'managed by the authenticated Content Owner' do
       let(:id) { ENV['YT_TEST_VIDEO_CHANNEL_ID'] }
 
+      describe 'advertising options can be retrieved' do
+        it { expect{video.advertising_options_set}.not_to raise_error }
+      end
+
       describe 'earnings can be retrieved for a specific day' do
         context 'in which the video made any money' do
           let(:earnings) {video.earnings_on 5.days.ago}
@@ -249,6 +253,18 @@ describe Yt::Video, :partner do
 
         expect(video.viewer_percentage(gender: :male)).to be_a Float
         expect(video.viewer_percentage(gender: :female)).to be_a Float
+      end
+    end
+
+    context 'given a video claimable by the authenticated Content Owner' do
+      let(:id) { ENV['YT_TEST_PARTNER_CLAIMABLE_VIDEO_ID'] }
+
+      describe 'the advertising formats can be updated and retrieved' do
+        let!(:old_formats) { video.ad_formats }
+        let!(:new_formats) { %w(standard_instream overlay trueview_instream).sample(2) }
+        before { video.advertising_options_set.update ad_formats: new_formats }
+        it { expect(video.ad_formats).to match_array new_formats }
+        after { video.advertising_options_set.update ad_formats: old_formats }
       end
     end
   end


### PR DESCRIPTION
This commit allows content owners to retrieve the advertising options
of a video, and in particular to list the ad formats.

Updating the advertising options was already possible, but retrieving
the data is required in order to be able to incrementally add ad formats.
