### PR TITLE
Allow statistics part on channels + viewer percentages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
-## 0.13.6 - unreleased
+## 0.13.6 - 2014-10-08
 
+* [ENHANCEMENT] Accept `includes(:viewer_percentages)` in `.partnered_channels` to eager-load multiple viewer percentages at once.
 * [ENHANCEMENT] Accept `where` in ViewerPercentages to collect data for multiple channels at once.
 * [ENHANCEMENT] Accept `part` in the `where` clause of Channels, so statistics can be loaded at once.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.13.6 - unreleased
+
+* [ENHANCEMENT] Accept `part` in the `where` clause of Channels, so statistics can be loaded at once.
+
 ## 0.13.5 - 2014-10-06
 
 * [ENHANCEMENT] Add `advertising_options_set` and `ad_formats` to video

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For more information about changelogs, check
 
 ## 0.13.6 - unreleased
 
+* [ENHANCEMENT] Accept `where` in ViewerPercentages to collect data for multiple channels at once.
 * [ENHANCEMENT] Accept `part` in the `where` clause of Channels, so statistics can be loaded at once.
 
 ## 0.13.5 - 2014-10-06

--- a/README.md
+++ b/README.md
@@ -113,7 +113,8 @@ Use [Yt::ContentOwner](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Models
 content_owner = Yt::ContentOwner.new owner_name: 'CMSname', access_token: 'ya29.1.ABCDEFGHIJ'
 
 content_owner.partnered_channels.count #=> 12
-content_owner.partnered_channels.first #=> #<Yt::Models::Channel @id=...>
+content_owner.partnered_channels.map &:title #=> ["Fullscreen", "Best of Fullscreen", ...]
+content_owner.partnered_channels.where(part: 'statistics').map &:subscriber_count #=> [136925, 56945, ...]
 
 content_owner.claims.where(q: 'Fullscreen').count #=> 24
 content_owner.claims.first #=> #<Yt::Models::Claim @id=...>

--- a/README.md
+++ b/README.md
@@ -446,6 +446,21 @@ videos.where(id: 'MESycYJytkU,invalid').map(&:title) #=> ["Fullscreen Creator Pl
 
 *The methods above do not require authentication.*
 
+Yt::Collections::ViewerPercentages
+----------------------------------
+
+Use [Yt::Collections::ViewerPercentages](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Collections/ViewerPercentages) to:
+
+* retrieve the viewer percentage of a set of channels
+
+```ruby
+content_owner = Yt::ContentOwner.new owner_name: 'CMSname', access_token: 'ya29.1.ABCDEFGHIJ'
+viewer_percentages = Yt::Collections::ViewerPercentages.new(auth: content_owner).where filters: 'channel==UCxO1tY8h1AhOz0T4ENwmpow,UCggO99g88eUDPcqkTShOPvw', ids: 'contentOwner==CMSname'
+viewer_percentages['UCxO1tY8h1AhOz0T4ENwmpow'] #=> {female: {'18-24' => 12.12, '25-34' => 16.16,…}…}
+viewer_percentages['UCggO99g88eUDPcqkTShOPvw'] #=> {female: {'18-24' => 40.12, '25-34' => 13.57,…}…}
+```
+
+*The methods above require to be authenticated as the channels’ content owner (see below).*
 
 Yt::Annotation
 --------------

--- a/README.md
+++ b/README.md
@@ -115,6 +115,8 @@ content_owner = Yt::ContentOwner.new owner_name: 'CMSname', access_token: 'ya29.
 content_owner.partnered_channels.count #=> 12
 content_owner.partnered_channels.map &:title #=> ["Fullscreen", "Best of Fullscreen", ...]
 content_owner.partnered_channels.where(part: 'statistics').map &:subscriber_count #=> [136925, 56945, ...]
+content_owner.partnered_channels.includes(:viewer_percentages).map &:viewer_percentages #=> [{female: {'18-24' => 12.12,…}…}, {female: {'18-24' => 40.12,…}…}, …]
+
 
 content_owner.claims.where(q: 'Fullscreen').count #=> 24
 content_owner.claims.first #=> #<Yt::Models::Claim @id=...>
@@ -446,21 +448,6 @@ videos.where(id: 'MESycYJytkU,invalid').map(&:title) #=> ["Fullscreen Creator Pl
 
 *The methods above do not require authentication.*
 
-Yt::Collections::ViewerPercentages
-----------------------------------
-
-Use [Yt::Collections::ViewerPercentages](http://rubydoc.info/github/Fullscreen/yt/master/Yt/Collections/ViewerPercentages) to:
-
-* retrieve the viewer percentage of a set of channels
-
-```ruby
-content_owner = Yt::ContentOwner.new owner_name: 'CMSname', access_token: 'ya29.1.ABCDEFGHIJ'
-viewer_percentages = Yt::Collections::ViewerPercentages.new(auth: content_owner).where filters: 'channel==UCxO1tY8h1AhOz0T4ENwmpow,UCggO99g88eUDPcqkTShOPvw', ids: 'contentOwner==CMSname'
-viewer_percentages['UCxO1tY8h1AhOz0T4ENwmpow'] #=> {female: {'18-24' => 12.12, '25-34' => 16.16,…}…}
-viewer_percentages['UCggO99g88eUDPcqkTShOPvw'] #=> {female: {'18-24' => 40.12, '25-34' => 13.57,…}…}
-```
-
-*The methods above require to be authenticated as the channels’ content owner (see below).*
 
 Yt::Annotation
 --------------

--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -84,7 +84,11 @@ module Yt
         params[:params][:page_token] = @page_token if @page_token
         next_page = fetch_page params
         @page_token = next_page[:token]
-        next_page[:items]
+        eager_load_items_from next_page[:items]
+      end
+
+      def eager_load_items_from(items)
+        items
       end
 
       def fetch_page(params = {})

--- a/lib/yt/actions/list.rb
+++ b/lib/yt/actions/list.rb
@@ -6,8 +6,8 @@ require 'yt/config'
 module Yt
   module Actions
     module List
-      delegate :count, :first, :any?, :each, :map, :flat_map, :find,
-        :size, to: :list
+      delegate :any?, :count, :each, :each_cons, :each_slice, :find, :first,
+        :flat_map, :map, :size, to: :list
 
       def first!
         first.tap{|item| raise Errors::NoItems, error_message unless item}

--- a/lib/yt/associations/has_viewer_percentages.rb
+++ b/lib/yt/associations/has_viewer_percentages.rb
@@ -38,7 +38,7 @@ module Yt
       def define_viewer_percentages_method
         # @todo: add options like start and end date
         define_method :viewer_percentages do
-          @viewer_percentages ||= Collections::ViewerPercentages.of(self).all
+          @viewer_percentages ||= Collections::ViewerPercentages.of(self)[id]
         end
       end
 

--- a/lib/yt/collections/channels.rb
+++ b/lib/yt/collections/channels.rb
@@ -22,7 +22,8 @@ module Yt
       end
 
       def channels_params
-        params = resources_params.merge mine: true
+        params = resources_params
+        params.merge! mine: true if @parent
         apply_where_params! params
       end
     end

--- a/lib/yt/collections/channels.rb
+++ b/lib/yt/collections/channels.rb
@@ -9,6 +9,12 @@ module Yt
 
     private
 
+      def attributes_for_new_item(data)
+        super(data).tap do |attributes|
+          attributes[:statistics] = data['statistics']
+        end
+      end
+
       # @return [Hash] the parameters to submit to YouTube to list channels.
       # @see https://developers.google.com/youtube/v3/docs/channels/list
       def list_params
@@ -16,7 +22,8 @@ module Yt
       end
 
       def channels_params
-        resources_params.merge mine: true
+        params = resources_params.merge mine: true
+        apply_where_params! params
       end
     end
   end

--- a/lib/yt/collections/partnered_channels.rb
+++ b/lib/yt/collections/partnered_channels.rb
@@ -13,7 +13,7 @@ module Yt
         super.tap do |params|
           params.delete :mine
           params[:managed_by_me] = true
-          params[:on_behalf_of_content_owner] = @parent.owner_name
+          params[:on_behalf_of_content_owner] = @auth.owner_name
         end
       end
 

--- a/lib/yt/collections/partnered_channels.rb
+++ b/lib/yt/collections/partnered_channels.rb
@@ -4,7 +4,34 @@ module Yt
   module Collections
     class PartneredChannels < Channels
 
+      def includes(relationship)
+        self.tap do
+          @items = []
+          @includes_relationship = relationship
+        end
+      end
+
     private
+
+      def attributes_for_new_item(data)
+        super(data).tap do |attributes|
+          attributes[:viewer_percentages] = data['viewerPercentages']
+        end
+      end
+
+      def eager_load_items_from(items)
+        if @includes_relationship == :viewer_percentages
+          filters = "channel==#{items.map{|item| item['id']}.join(',')}"
+          ids = "contentOwner==#{@auth.owner_name}"
+          conditions = {ids: ids, filters: filters}
+          viewer_percentages = Collections::ViewerPercentages.new auth: @auth
+          viewer_percentages = viewer_percentages.where conditions
+          items.each do |item|
+            item['viewerPercentages'] = viewer_percentages[item['id']]
+          end
+        end
+        items
+      end
 
       # @private
       # @note Partnered Channels overwrites +channel_params+ since the query

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -63,6 +63,15 @@ module Yt
       #     return an authenticated account.
       has_one :subscription
 
+      # Override Resource's new to set statistics as well
+      # if the response includes them
+      def initialize(options = {})
+        super options
+        if options[:statistics]
+          @statistics_set = StatisticsSet.new data: options[:statistics]
+        end
+      end
+
       # Returns whether the authenticated account is subscribed to the channel.
       #
       # This method requires {Resource#auth auth} to return an

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -70,6 +70,9 @@ module Yt
         if options[:statistics]
           @statistics_set = StatisticsSet.new data: options[:statistics]
         end
+        if options[:viewer_percentages]
+          @viewer_percentages = options[:viewer_percentages]
+        end
       end
 
       # Returns whether the authenticated account is subscribed to the channel.

--- a/lib/yt/models/channel.rb
+++ b/lib/yt/models/channel.rb
@@ -158,10 +158,10 @@ module Yt
       def reports_params
         {}.tap do |params|
           if auth.owner_name
-            params['ids'] = "contentOwner==#{auth.owner_name}"
-            params['filters'] = "channel==#{id}"
+            params[:ids] = "contentOwner==#{auth.owner_name}"
+            params[:filters] = "channel==#{id}"
           else
-            params['ids'] = "channel==#{id}"
+            params[:ids] = "channel==#{id}"
           end
         end
       end

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -167,11 +167,11 @@ module Yt
       def reports_params
         {}.tap do |params|
           if auth.owner_name
-            params['ids'] = "contentOwner==#{auth.owner_name}"
+            params[:ids] = "contentOwner==#{auth.owner_name}"
           else
-            params['ids'] = "channel==#{channel_id}"
+            params[:ids] = "channel==#{channel_id}"
           end
-          params['filters'] = "video==#{id}"
+          params[:filters] = "video==#{id}"
         end
       end
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.13.5'
+  VERSION = '0.13.6'
 end

--- a/spec/requests/as_account/channels_spec.rb
+++ b/spec/requests/as_account/channels_spec.rb
@@ -7,7 +7,7 @@ describe Yt::Collections::Channels, :device_app do
 
   context 'with a list of parts' do
     let(:part) { 'statistics' }
-    let(:channel) { channels.where(part: part).first }
+    let(:channel) { channels.where(part: part, id: 'UCxO1tY8h1AhOz0T4ENwmpow').first }
 
     specify 'load ONLY the specified parts of the channels' do
       expect(channel.instance_variable_defined? :@snippet).to be false

--- a/spec/requests/as_account/channels_spec.rb
+++ b/spec/requests/as_account/channels_spec.rb
@@ -1,0 +1,18 @@
+# encoding: UTF-8
+require 'spec_helper'
+require 'yt/collections/channels'
+
+describe Yt::Collections::Channels, :device_app do
+  subject(:channels) { Yt::Collections::Channels.new auth: $account }
+
+  context 'with a list of parts' do
+    let(:part) { 'statistics' }
+    let(:channel) { channels.where(part: part).first }
+
+    specify 'load ONLY the specified parts of the channels' do
+      expect(channel.instance_variable_defined? :@snippet).to be false
+      expect(channel.instance_variable_defined? :@status).to be false
+      expect(channel.instance_variable_defined? :@statistics_set).to be true
+    end
+  end
+end

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -2,12 +2,24 @@ require 'spec_helper'
 require 'yt/models/content_owner'
 
 describe Yt::ContentOwner, :partner do
-  describe '.partnered_channels.first' do
-    it { expect($content_owner.partnered_channels.first).to be_a Yt::Channel }
-  end
+  describe '.partnered_channels' do
+    let(:partnered_channels) { $content_owner.partnered_channels }
 
-  describe '.partnered_channels.size', :ruby2 do
-    it { expect($content_owner.partnered_channels.size).to be > 0 }
+    specify '.first' do
+      expect(partnered_channels.first).to be_a Yt::Channel
+    end
+
+    specify '.size', :ruby2 do
+      expect(partnered_channels.size).to be > 0
+    end
+
+    context 'with includes(:viewer_percentages)' do
+      let(:channel) { partnered_channels.includes(:viewer_percentages).first }
+
+      specify 'eager-loads the viewer percentages of each channel' do
+        expect(channel.instance_variable_defined? :@viewer_percentages).to be true
+      end
+    end
   end
 
   describe 'claims' do

--- a/spec/requests/as_content_owner/viewer_percentages_spec.rb
+++ b/spec/requests/as_content_owner/viewer_percentages_spec.rb
@@ -1,0 +1,18 @@
+# encoding: UTF-8
+require 'spec_helper'
+require 'yt/collections/viewer_percentages'
+
+describe Yt::Collections::ViewerPercentages, :partner do
+  subject(:viewer_percentages) { Yt::Collections::ViewerPercentages.new auth: $content_owner }
+
+  context 'for two channels at once' do
+    let(:filters) { 'channel==UCxO1tY8h1AhOz0T4ENwmpow,UCsmvakQZlvGsyjyOhmhvOsw' }
+    let(:ids) { "contentOwner==#{$content_owner.owner_name}" }
+    let(:result) { viewer_percentages.where filters: filters, ids: ids }
+
+    it 'returns the viewer percentages of both' do
+      expect(result['UCggO99g88eUDPcqkTShOPvw'][:female]['18-24']).to be_a Float
+      expect(result['UC8oJ8Sdgkpcy4gylGjTHtBw'][:male]['18-24']).to be_a Float
+    end
+  end
+end


### PR DESCRIPTION
@stavro @Nuru This stems from my comment https://github.com/Fullscreen/yt/pull/31#issuecomment-58373026 so read that first.

In order to achieve what I describe there (having `select` and `includes` working on `.partnered_channels`), we first need the related Collection to accept those parameters and eager-load the requested data. This is what the current PR provides.

After the current PR, you will be able to do the following:

``` ruby
yt_channels = yt_content_owner.partnered_channels.where(part: 'statistics')

ids = "contentOwner==#{yt_content_owner.owner_name}"
filters = "channel==#{yt_channels.map(&:id).join ','}"
viewer_percentages = Yt::Collections::ViewerPercentages.new(auth: content_owner).where ids: ids, filters: filters

yt_channels.each do |yt_channel|
  channel = Channel.find_or_initialize_by slug: yt_channel.id
  channel.reach = yt_channel.subscriber_count
  channel.demographics = viewer_percentages[yt_channel.id]
  channel.save
end
```

If the number of partnered channels is <= 50, then this works perfectly, and **only uses two queries**.
However, as @Nuru pointed out in https://github.com/Fullscreen/yt/pull/31#issuecomment-58394525 this approach needs to be slightly adapted if there are more partnered channels, because:
- we cannot collect all their IDs at once with `yt_channels.map(&:id)` (they are paginated)
- we cannot ask YouTube Analytics API for more than 200 channels in each request

Thoughts?
