### PR TITLE
Fix: remove has_one :claim from Yt::Video

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ For more information about changelogs, check
 [Keep a Changelog](http://keepachangelog.com) and
 [Vandamme](http://tech-angels.github.io/vandamme).
 
+## 0.25.31 - 2016-04-11
+
+* [BUGFIX] Don’t try to instantiate video.claim if a video does not have a claim.
+
 ## 0.25.30 - 2016-04-07
 
 * [FEATURE] Add ability for videos to eager load claims. For example, `$content_owner.videos.includes(:claim).first.claim.id`.

--- a/lib/yt/collections/claims.rb
+++ b/lib/yt/collections/claims.rb
@@ -37,12 +37,7 @@ module Yt
       end
 
       def claims_params
-        if @parent.respond_to? :owner_name
-          owner_name = @parent.owner_name
-        else
-          owner_name = @auth.owner_name
-        end
-        apply_where_params! on_behalf_of_content_owner: owner_name
+        apply_where_params! on_behalf_of_content_owner: @parent.owner_name
       end
 
       # @private

--- a/lib/yt/collections/videos.rb
+++ b/lib/yt/collections/videos.rb
@@ -26,8 +26,8 @@ module Yt
           attributes[:content_details] = data['contentDetails']
           attributes[:statistics] = data['statistics']
           attributes[:video_category] = data['videoCategory']
-          attributes[:auth] = @auth
           attributes[:claim] = data['claim']
+          attributes[:auth] = @auth
         end
       end
 
@@ -57,7 +57,7 @@ module Yt
           if include_claim
             video_ids = items.map{|item| item['id']['videoId']}.uniq
             conditions = { video_id: video_ids.join(',') }
-            claims = Collections::Claims.new(auth: @auth, parent: @parent).where conditions
+            claims = @parent.claims.where conditions
             items.each do |item|
               claim = claims.find { |c| c.video_id == item['id']['videoId']}
               item['claim'] = claim

--- a/lib/yt/models/video.rb
+++ b/lib/yt/models/video.rb
@@ -379,6 +379,13 @@ module Yt
 
       has_many :resumable_sessions
 
+      # @!attribute [r] channel
+      #   @return [Yt::Models::Claim, nil] the first claim on the video by
+      #     the content owner of the video, if eagerly loaded.
+      def claim
+        @claim
+      end
+
     ### ANALYTICS ###
 
       # @macro reports
@@ -553,10 +560,6 @@ module Yt
       def update(attributes = {})
         super
       end
-
-    ### Claim ###
-
-      has_one :claim
 
     ### PRIVATE API ###
 

--- a/lib/yt/version.rb
+++ b/lib/yt/version.rb
@@ -1,3 +1,3 @@
 module Yt
-  VERSION = '0.25.30'
+  VERSION = '0.25.31'
 end

--- a/spec/requests/as_content_owner/content_owner_spec.rb
+++ b/spec/requests/as_content_owner/content_owner_spec.rb
@@ -51,12 +51,13 @@ describe Yt::ContentOwner, :partner do
     end
 
     describe '.includes(:claim)' do
-      let(:video) { $content_owner.videos.includes(:claim).first }
+      let(:videos) { $content_owner.videos.includes(:claim) }
+      let(:video_with_claim) { videos.find{|v| v.claim.present?} }
 
       specify 'eager-loads the claim of each video' do
-        expect(video.instance_variable_defined? :@claim).to be true
-        expect(video.claim.id).to be_a String
-        expect(video.claim.video_id).to eq video.id
+        expect(video_with_claim.claim).to be_a Yt::Claim
+        expect(video_with_claim.claim.id).to be_a String
+        expect(video_with_claim.claim.video_id).to eq video_with_claim.id
       end
     end
   end


### PR DESCRIPTION
We cannot assume that every video has a claim. We can still try to
eagerly loaded the claims when we need to, but we should not use
`has_one`, since it assumes the existence of the association.
