### PR TITLE
Fix Ruby 4.0 compatibility: replace deprecated CGI.parse

### DIFF
--- a/lib/yt/models/resumable_session.rb
+++ b/lib/yt/models/resumable_session.rb
@@ -1,4 +1,3 @@
-require 'cgi'
 require 'yt/models/base'
 
 module Yt
@@ -30,7 +29,7 @@ module Yt
     private
 
       def session_params
-        CGI::parse(@uri.query).tap{|hash| hash.each{|k,v| hash[k] = v.first}}
+        URI.decode_www_form(@uri.query || "").to_h
       end
 
       # @note: YouTube documentation states that a valid upload returns an HTTP


### PR DESCRIPTION
## Summary

- Replace `CGI.parse` with `URI.decode_www_form` in `ResumableSession`
- Remove unused `require 'cgi'`

## Context

Ruby 4.0 removed the `cgi` library from the standard library. Only `cgi/escape` remains available for basic escaping methods. This causes the following error when uploading videos: undefined method 'parse' for class CGI

## Solution
Use `URI.decode_www_form` which is part of Ruby's core `URI` library and provides identical functionality. This is the recommended replacement per Ruby documentation.

**Before:**
 ```ruby
 CGI::parse(@uri.query).tap{|hash| hash.each{|k,v| hash[k] = v.first}}
 ```
 
 **After:**
  ```ruby
  URI.decode_www_form(@uri.query || "").to_h
  ```
Testing
This change is backwards compatible with Ruby 3.x as URI.decode_www_form has been available since Ruby 1.9.2.