### PR TITLE
Add shorts video url for a pattern

### DIFF
--- a/lib/yt/models/resource.rb
+++ b/lib/yt/models/resource.rb
@@ -91,6 +91,7 @@ module Yt
         %r{^(?:https?://)?(?:www\.)?youtu\.be/(?<id>[a-zA-Z0-9_-]{11})},
         %r{^(?:https?://)?(?:www\.)?youtube\.com/embed/(?<id>[a-zA-Z0-9_-]{11})},
         %r{^(?:https?://)?(?:www\.)?youtube\.com/v/(?<id>[a-zA-Z0-9_-]{11})},
+        %r{^(?:https?://)?(?:www\.)?youtube\.com/shorts/(?<id>[a-zA-Z0-9_-]{11})},
       ]
 
       # @return [Array<Regexp>] patterns matching URLs of YouTube channels.


### PR DESCRIPTION
```
> Yt::Video.new(url: "https://www.youtube.com/shorts/A2sWVxvFkVo").id
=> "UC0yMjJFNFlRTzZMZmxqUDFH"
```

Currently, unexpected behavior happens (returns a channel id). After this change,

```
> Yt::Video.new(url: "https://www.youtube.com/shorts/A2sWVxvFkVo").id
=> "A2sWVxvFkVo"
```